### PR TITLE
add Command.isStrict option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Packages
 Package.pins
 Package.resolved
 .DS_Store
+DerivedData

--- a/Sources/Command/Command/Command.swift
+++ b/Sources/Command/Command/Command.swift
@@ -75,11 +75,20 @@ public protocol Command: CommandRunnable {
     ///
     /// See `CommandArgument` for more information.
     var arguments: [CommandArgument] { get }
+    
+    /// When `true`, excess arguments and unknown options will trigger an error.
+    /// Defaults to `true`.
+    var isStrict: Bool { get }
 }
 
 extension Command {
     /// See `CommandRunnable`
     public var type: CommandRunnableType {
         return .command(arguments: arguments)
+    }
+    
+    /// See `Command`.
+    public var isStrict: Bool {
+        return true
     }
 }

--- a/Sources/Command/Run/CommandContext.swift
+++ b/Sources/Command/Run/CommandContext.swift
@@ -12,6 +12,9 @@ public struct CommandContext {
 
     /// The parsed options (according to declared signature).
     public var options: [String: String]
+    
+    /// Extraneous arguments that did not match the commands defined arguments.
+    public var excess: [String]
 
     /// The container this command is running on.
     public var container: Container
@@ -21,11 +24,13 @@ public struct CommandContext {
         console: Console,
         arguments: [String: String],
         options: [String: String],
+        excess: [String] = [],
         on container: Container
     ) {
         self.console = console
         self.arguments = arguments
         self.options = options
+        self.excess = excess
         self.container = container
     }
 
@@ -64,6 +69,7 @@ public struct CommandContext {
         from input: inout CommandInput,
         console: Console,
         for runnable: CommandRunnable,
+        isStrict: Bool,
         on container: Container
     ) throws -> CommandContext {
         var parsedArguments: [String: String] = [:]
@@ -91,7 +97,7 @@ public struct CommandContext {
         }
 
 
-        guard input.arguments.count == 0 else {
+        guard !isStrict || input.arguments.count == 0 else {
             throw CommandError(
                 identifier: "excessInput",
                 reason: "Too many arguments or unsupported options were supplied: \(input.arguments)",
@@ -103,6 +109,7 @@ public struct CommandContext {
             console: console,
             arguments: parsedArguments,
             options: parsedOptions,
+            excess: input.arguments,
             on: container
         )
     }

--- a/Sources/Command/Run/Console+Run.swift
+++ b/Sources/Command/Run/Console+Run.swift
@@ -82,7 +82,13 @@ extension Console {
             case .command: break
             }
 
-            let context = try CommandContext.make(from: &input, console: self, for: runnable, on: container)
+            let context = try CommandContext.make(
+                from: &input,
+                console: self,
+                for: runnable,
+                isStrict: (runnable as? Command)?.isStrict ?? true,
+                on: container
+            )
             return try runnable.run(using: context)
         }
     }

--- a/Sources/ConsoleDevelopment/main.swift
+++ b/Sources/ConsoleDevelopment/main.swift
@@ -1,1 +1,73 @@
 /// Test code here
+import Command
+
+final class StrictCommand: Command {
+    var arguments: [CommandArgument] {
+        return []
+    }
+    
+    var options: [CommandOption] {
+        return [.flag(name: "release")]
+    }
+    
+    var help: [String] {
+        return []
+    }
+    
+    func run(using context: CommandContext) throws -> EventLoopFuture<Void> {
+        print(context.excess)
+        return context.container.future()
+    }
+    
+    
+}
+
+final class LaxCommand: Command {
+    var arguments: [CommandArgument] {
+        return []
+    }
+    
+    var options: [CommandOption] {
+        return [.flag(name: "release")]
+    }
+    
+    var help: [String] {
+        return []
+    }
+    
+    var isStrict: Bool {
+        return false
+    }
+    
+    func run(using context: CommandContext) throws -> EventLoopFuture<Void> {
+        print(context.excess)
+        return context.container.future()
+    }
+}
+
+final class TestCommands: CommandGroup {
+    var commands: Commands {
+        return [
+            "lax": LaxCommand(),
+            "strict": StrictCommand()
+        ]
+    }
+    
+    var options: [CommandOption] {
+        return []
+    }
+    
+    var help: [String] {
+        return []
+    }
+    
+    func run(using context: CommandContext) throws -> EventLoopFuture<Void> {
+        return context.container.future()
+    }
+}
+
+
+let console = Terminal()
+let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+let container = BasicContainer(config: .init(), environment: .development, services: .init(), on: elg.next())
+try console.run(TestCommands(), input: &container.environment.commandInput, on: container).wait()


### PR DESCRIPTION
Adds a new optional protocol member `Command.isStrict` to specify whether input should be validated for a given command. If set to `false`, extraneous command arguments will be tolerated and accessible via `CommandContext.excess`. If `true`, extraneous command arguments will result in an error and `CommandContext.excess` will always be empty. To maintain backward compatibility, this property defaults to `true` if not implemented.

The reasoning behind adding this option is to make it possible for commands like `vapor run` to accept arbitrary arguments / flags that will be passed to an underlying command.

See `ConsoleDevelopment/main.swift` for example usage. 
