### PR TITLE
add projected values to wrappers

### DIFF
--- a/Sources/ConsoleKit/Command/Argument.swift
+++ b/Sources/ConsoleKit/Command/Argument.swift
@@ -35,6 +35,10 @@ public final class Argument<Value>: AnyArgument
 
     var value: Value?
 
+    public var projectedValue: Argument<Value> {
+        return self
+    }
+
     /// @propertyWrapper value
     public var wrappedValue: Value {
         guard let value = self.value else {

--- a/Sources/ConsoleKit/Command/Flag.swift
+++ b/Sources/ConsoleKit/Command/Flag.swift
@@ -13,6 +13,10 @@ public final class Flag: AnyFlag {
     /// The option's help text when `--help` is passed in.
     public let short: Character?
 
+    public var projectedValue: Flag {
+        return self
+    }
+
     public var wrappedValue: Bool {
         guard let value = self.value else {
             fatalError("Flag \(self.name) was not initialized")

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -15,6 +15,9 @@ public final class Option<Value>: AnyOption
     /// The option's help text when `--help` is passed in.
     public let short: Character?
 
+    public var projectedValue: Option<Value> {
+        return self
+    }
 
     public var wrappedValue: Value? {
         guard let value = self.value else {

--- a/Tests/ConsoleKitTests/CommandTests.swift
+++ b/Tests/ConsoleKitTests/CommandTests.swift
@@ -8,7 +8,7 @@ class CommandTests: XCTestCase {
         let input = CommandInput(arguments: ["vapor", "sub", "test", "--help"])
         try console.run(group, input: input)
         XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
-        Usage: vapor sub test <foo> [--bar,-b]\u{20}
+        Usage: vapor sub test <foo> [--bar,-b] [--baz,-B]\u{20}
 
         This is a test command
 
@@ -19,6 +19,10 @@ class CommandTests: XCTestCase {
         Options:
           bar Add a bar if you so desire
               Try passing it
+
+        Flags:
+          baz Add a baz if you so desire
+              It's just a flag
 
         """)
     }

--- a/Tests/ConsoleKitTests/Utilities.swift
+++ b/Tests/ConsoleKitTests/Utilities.swift
@@ -1,4 +1,5 @@
 import ConsoleKit
+import XCTest
 
 extension String: Error {}
 
@@ -57,12 +58,21 @@ final class TestCommand: Command {
         """)
         var bar: String?
 
+        @Flag(name: "baz", short: "B", help: """
+        Add a baz if you so desire
+        It's just a flag
+        """)
+        var baz: Bool
+
         init() { }
     }
 
     let help: String = "This is a test command"
 
     func run(using context: CommandContext, signature: Signature) throws {
+        XCTAssertEqual(signature.$foo.name, "foo")
+        XCTAssertEqual(signature.$bar.name, "bar")
+        XCTAssertEqual(signature.$baz.name, "baz")
         context.console.output("Foo: \(signature.foo) Bar: \(signature.bar ?? "nil")".consoleText(.info))
     }
 }


### PR DESCRIPTION
This change allows for `@Option`, `@Argument`, and `@Flag` wrappers to be accessed using the `$` prefix. This makes it easier for users to extend these wrappers and access their internal storage.