### PR TITLE
Implement enum based CommandError

### DIFF
--- a/Sources/ConsoleKit/Command/Argument.swift
+++ b/Sources/ConsoleKit/Command/Argument.swift
@@ -61,10 +61,10 @@ public final class Argument<Value>: AnyArgument
 
     func load(from input: inout CommandInput) throws {
         guard let argument = input.nextArgument() else {
-            throw CommandError(identifier: "argument", reason: "Missing required argument: \(self.name)")
+            throw CommandError.missingRequiredArgument(self.name)
         }
         guard let value = Value(argument) else {
-            throw CommandError(identifier: "argument", reason: "Could not convert argument for \(self.name) to \(Value.self)")
+            throw CommandError.invalidArgumentType(self.name, type: Value.self)
         }
         self.value = value
     }

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -1,11 +1,29 @@
 /// Errors working with the `Command` module.
-public enum CommandError: Error, CustomStringConvertible {
+public enum CommandError: Error, Equatable, CustomStringConvertible {
     case missingCommand
     case unknownCommand(_ command: String, available: [String])
     case missingRequiredArgument(_ argument: String)
     case invalidArgumentType(_ argument: String, type: Any.Type)
     case invalidOptionType(_ option: String, type: Any.Type)
 
+    /// See `Equable`
+    public static func == (lhs: CommandError, rhs: CommandError) -> Bool {
+        switch (lhs, rhs) {
+        case (.missingCommand, .missingCommand):
+            return true
+        case (let .unknownCommand(cmdL, availL), let .unknownCommand(cmdR, available: availR)):
+            return cmdL == cmdR && availL == availR
+        case (let .missingRequiredArgument(argL), let .missingRequiredArgument(argR)):
+            return argL == argR
+        case (let .invalidArgumentType(argL, type: tL), let .invalidArgumentType(argR, type: tR)):
+            return argL == argR && tL == tR
+        case (let .invalidOptionType(optL, type: tL), let .invalidOptionType(optR, type: tR)):
+            return optL == optR && tL == tR
+        default:
+            return false
+        }
+    }
+    
     /// See `CustomStringConvertible`.
     public var description: String {
         switch self {

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -6,7 +6,7 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
     case invalidArgumentType(_ argument: String, type: Any.Type)
     case invalidOptionType(_ option: String, type: Any.Type)
 
-    /// See `Equable`
+    /// See `Equatable`
     public static func == (lhs: CommandError, rhs: CommandError) -> Bool {
         switch (lhs, rhs) {
         case (.missingCommand, .missingCommand):

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -12,7 +12,7 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
         case (.missingCommand, .missingCommand):
             return true
         case (let .unknownCommand(cmdL, availL), let .unknownCommand(cmdR, available: availR)):
-            return cmdL == cmdR && availL == availR
+            return cmdL == cmdR && availL.sorted() == availR.sorted()
         case (let .missingRequiredArgument(argL), let .missingRequiredArgument(argR)):
             return argL == argR
         case (let .invalidArgumentType(argL, type: tL), let .invalidArgumentType(argR, type: tR)):

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -53,9 +53,9 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
         case let .missingRequiredArgument(argument):
             return "Error: Missing required argument: \(argument)"
         case let .invalidArgumentType(argument, type: type):
-            return "Error: Could not convert argument for \(argument) to \(type)"
+            return "Error: Could not convert argument for `\(argument)` to \(type)"
         case let .invalidOptionType(option, type: type):
-            return "Error: Could not convert option for \(option) to \(type)"
+            return "Error: Could not convert option for `\(option)` to \(type)"
         }
     }
 }

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -11,7 +11,7 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
         switch (lhs, rhs) {
         case (.missingCommand, .missingCommand):
             return true
-        case (let .unknownCommand(cmdL, availL), let .unknownCommand(cmdR, available: availR)):
+        case (let .unknownCommand(cmdL, available: availL), let .unknownCommand(cmdR, available: availR)):
             return cmdL == cmdR && availL.sorted() == availR.sorted()
         case (let .missingRequiredArgument(argL), let .missingRequiredArgument(argR)):
             return argL == argR

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -1,47 +1,44 @@
 /// Errors working with the `Command` module.
-public struct CommandError: Error, CustomStringConvertible {
-    /// See `Debuggable`.
-    public let identifier: String
-
-    /// See `Debuggable`.
-    public let reason: String
-    
-    /// The name of the attempted command
-    public let command: String?
-    
-    /// All available commands
-    public let availableCommands: [String]
+public enum CommandError: Error, CustomStringConvertible {
+    case missingCommand
+    case unknownCommand(_ command: String, available: [String])
+    case missingRequiredArgument(_ argument: String)
+    case invalidArgumentType(_ argument: String, type: Any.Type)
+    case invalidOptionType(_ option: String, type: Any.Type)
 
     /// See `CustomStringConvertible`.
     public var description: String {
-        guard let name = command, !availableCommands.isEmpty else {
-            return "\(self.identifier): \(self.reason)"
+        switch self {
+        case .missingCommand:
+            return "Error: Missing command"
+        case let .unknownCommand(command, available: available):
+            guard !available.isEmpty else {
+                return "Error: Executable doesn't take a command"
+            }
+            
+            let suggestions: [(String, Int)] = available
+                .map { ($0, $0.levenshteinDistance(to: command)) }
+                .sorted(by: smallerDistance)
+                .filter(distanceLessThan(3))
+            
+            guard !suggestions.isEmpty else {
+                return "Error: Unknown command `\(command)`"
+            }
+            
+            return """
+            Error: Unknown command `\(command)`
+            
+            Did you mean this?
+            
+            \(suggestions.map { "\t\($0.0)" }.joined(separator: "\n"))
+            """
+        case let .missingRequiredArgument(argument):
+            return "Error: Missing required argument: \(argument)"
+        case let .invalidArgumentType(argument, type: type):
+            return "Error: Could not convert argument for \(argument) to \(type)"
+        case let .invalidOptionType(option, type: type):
+            return "Error: Could not convert option for \(option) to \(type)"
         }
-        
-        let suggestions: [(String, Int)] = availableCommands
-            .map { ($0, $0.levenshteinDistance(to: name)) }
-            .sorted(by: smallerDistance)
-            .filter(distanceLessThan(3))
-        
-        guard !suggestions.isEmpty else {
-            return "Error: \(self.reason)"
-        }
-        
-        return """
-        Error: \(self.reason)
-
-        Did you mean this?
-
-        \(suggestions.map { "\t\($0.0)" }.joined(separator: "\n"))
-        """
-    }
-
-    /// Creates a new `CommandError`
-    internal init(identifier: String, reason: String, forCommand command: String? = nil, availableCommands: [String] = []) {
-        self.identifier = identifier
-        self.reason = reason
-        self.command = command
-        self.availableCommands = availableCommands
     }
 }
 

--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -60,11 +60,27 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
     }
 }
 
-
 private func smallerDistance(lhs: (String, Int), rhs: (String, Int)) -> Bool {
     return lhs.1 < rhs.1
 }
 
 private func distanceLessThan(_ threshold: Int) -> (String, Int) -> Bool {
     return { command, distance in distance < threshold }
+}
+
+extension CommandError: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .missingCommand:
+            return #".missingCommand"#
+        case let .unknownCommand(command, available: available):
+            return #".unknownCommand("\#(command)", available: \#(available))"#
+        case let .missingRequiredArgument(argument):
+            return #".missingRequiredArgument("\#(argument)")"#
+        case let .invalidArgumentType(argument, type: type):
+            return #".invalidArgumentType("\#(argument)", type: \#(type))"#
+        case let .invalidOptionType(option, type: type):
+            return #".invalidOptionType("\#(option)", type: \#(type))"#
+        }
+    }
 }

--- a/Sources/ConsoleKit/Command/CommandGroup.swift
+++ b/Sources/ConsoleKit/Command/CommandGroup.swift
@@ -29,7 +29,7 @@ extension CommandGroup {
             return try `default`.run(using: &context)
         } else {
             try self.outputHelp(using: &context)
-            throw CommandError(identifier: "noCommand", reason: "Missing command")
+            throw CommandError.missingCommand
         }
     }
 
@@ -80,12 +80,7 @@ extension CommandGroup {
     private func commmand(using context: inout CommandContext) throws -> AnyCommand? {
         if let name = context.input.arguments.popFirst() {
             guard let command = self.commands[name] else {
-                throw CommandError(
-                    identifier: "unknownCommand",
-                    reason: "Unknown command `\(name)`",
-                    forCommand: name,
-                    availableCommands: Array(self.commands.keys)
-                )
+                throw CommandError.unknownCommand(name, available: Array(self.commands.keys))
             }
             // executable should include all subcommands
             // to get to the desired command

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -49,7 +49,7 @@ public final class Option<Value>: AnyOption
     func load(from input: inout CommandInput) throws {
         if let option = input.nextOption(name: self.name, short: self.short) {
             guard let value = Value(option) else {
-                throw CommandError(identifier: "option", reason: "Could not convert option for \(self.name) to \(Value.self)")
+                throw CommandError.invalidOptionType(self.name, type: Value.self)
             }
             self.value = value
         } else {

--- a/Tests/ConsoleKitTests/CommandErrorTests.swift
+++ b/Tests/ConsoleKitTests/CommandErrorTests.swift
@@ -7,10 +7,11 @@ class CommandErrorTests: XCTestCase {
         let group = TestGroup()
         let input = CommandInput(arguments: ["vapor"])
         XCTAssertThrowsError(try console.run(group, input: input), "Missing command is supposed to throw") { error in
-            guard case .missingCommand = error as? CommandError else {
-                return XCTFail("Expected `.missingCommand` error, got \(error).")
+            guard let commandError = error as? CommandError else {
+                return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
-            XCTAssertEqual((error as! CommandError).description, "Error: Missing command")
+            XCTAssertEqual(commandError, .missingCommand, "Expected `.missingCommand` error, got \(String(reflecting: error)).")
+            XCTAssertEqual(commandError.description, "Error: Missing command")
         }
     }
     
@@ -19,10 +20,11 @@ class CommandErrorTests: XCTestCase {
         let group = TestGroup()
         let input = CommandInput(arguments: ["vapor", "sup"])
         XCTAssertThrowsError(try console.run(group, input: input), "Unknown command is supposed to throw") { error in
-            guard case .unknownCommand = error as? CommandError else {
-                return XCTFail("Expected `.unknownCommand` error, got \(error).")
+            guard let commandError = error as? CommandError else {
+                return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
-            XCTAssertEqual((error as! CommandError).description, """
+            XCTAssertEqual(commandError, .unknownCommand("sup", available: ["sub", "test"]), "Expected `.unknownCommand` error, got \(String(reflecting: error)).")
+            XCTAssertEqual(commandError.description, """
             Error: Unknown command `sup`
 
             Did you mean this?
@@ -37,17 +39,32 @@ class CommandErrorTests: XCTestCase {
         let group = TestGroup()
         let input = CommandInput(arguments: ["vapor", "desoxyribonucleic-acid"])
         XCTAssertThrowsError(try console.run(group, input: input), "Unknown command is supposed to throw") { error in
-            guard case .unknownCommand = error as? CommandError else {
-                return XCTFail("Expected `.unknownCommand` error, got \(error).")
+            guard let commandError = error as? CommandError else {
+                return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
-            XCTAssertEqual((error as! CommandError).description, """
+            XCTAssertEqual(commandError, .unknownCommand("desoxyribonucleic-acid", available: ["sub", "test"]), "Expected `.unknownCommand` error, got \(String(reflecting: error)).")
+            XCTAssertEqual(commandError.description, """
             Error: Unknown command `desoxyribonucleic-acid`
             """)
         }
     }
     
     func testCommandWithMissingRequiredArgument() throws {
-        // TODO: Implement
+        let console = TestConsole()
+        let command = StrictCommand()
+
+        var input = CommandInput(arguments: ["vapor", "3", "true"])
+        try console.run(command, input: input)
+
+        input = CommandInput(arguments: ["vapor"])
+        try XCTAssertThrowsError(console.run(command, input: input))
+        XCTAssertThrowsError(try console.run(command, input: input), "Missing argument is supposed to throw") { error in
+            guard let commandError = error as? CommandError else {
+                return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
+            }
+            XCTAssertEqual(commandError, .missingRequiredArgument("number"), "Expected `.missingRequiredArgument` error, got \(String(reflecting: error)).")
+            XCTAssertEqual(commandError.description, "Error: Missing required argument: number")
+        }
     }
     
     func testCommandWithInvalidArgumentType() throws {
@@ -59,16 +76,41 @@ class CommandErrorTests: XCTestCase {
 
         input = CommandInput(arguments: ["vapor", "e", "true"])
         try XCTAssertThrowsError(console.run(command, input: input))
-        XCTAssertThrowsError(try console.run(command, input: input), "Missing command is supposed to throw") { error in
-            guard case .invalidArgumentType = error as? CommandError else {
-                return XCTFail("Expected `.invalidArgumentType` error, got \(error).")
+        XCTAssertThrowsError(try console.run(command, input: input), "Invalid argument is supposed to throw") { error in
+            guard let commandError = error as? CommandError else {
+                return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
-            XCTAssertEqual((error as! CommandError).description, "Error: Could not convert argument for number to Int")
+            XCTAssertEqual(commandError, .invalidArgumentType("number", type: Int.self), "Expected `.invalidArgumentType` error, got \(String(reflecting: error)).")
+            XCTAssertEqual(commandError.description, "Error: Could not convert argument for `number` to Int")
         }
     }
     
     func testCommandWithInvalidOptionType() throws {
-        // TODO: Implement
+        final class IntOptionCommand: Command {
+            struct Signature: CommandSignature {
+                @Option(name: "bar", short: "b", help: "")
+                var bar: Int?
+                init() { }
+            }
+            let help: String = "This is a test command"
+            func run(using context: CommandContext, signature: Signature) throws {}
+        }
+        
+        let console = TestConsole()
+        let command = IntOptionCommand()
+        
+        var input = CommandInput(arguments: ["vapor", "--bar", "3"])
+        try console.run(command, input: input)
+        
+        input = CommandInput(arguments: ["vapor", "--bar", "a"])
+        try XCTAssertThrowsError(console.run(command, input: input))
+        XCTAssertThrowsError(try console.run(command, input: input), "Invalid argument is supposed to throw") { error in
+            guard let commandError = error as? CommandError else {
+                return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
+            }
+            XCTAssertEqual(commandError, .invalidOptionType("bar", type: Int.self), "Expected `.invalidOptionType` error, got \(String(reflecting: error)).")
+            XCTAssertEqual(commandError.description, "Error: Could not convert option for `bar` to Int")
+        }
     }
     
     func testLevenshteinDistance() {

--- a/Tests/ConsoleKitTests/CommandErrorTests.swift
+++ b/Tests/ConsoleKitTests/CommandErrorTests.swift
@@ -2,11 +2,26 @@
 import XCTest
 
 class CommandErrorTests: XCTestCase {
-    func testUnknownWithSuggestionCommand() throws {
+    func testMissingCommand() throws {
+        let console = TestConsole()
+        let group = TestGroup()
+        let input = CommandInput(arguments: ["vapor"])
+        XCTAssertThrowsError(try console.run(group, input: input), "Missing command is supposed to throw") { error in
+            guard case .missingCommand = error as? CommandError else {
+                return XCTFail("Expected `.missingCommand` error, got \(error).")
+            }
+            XCTAssertEqual((error as! CommandError).description, "Error: Missing command")
+        }
+    }
+    
+    func testUnknownCommandWithSuggestion() throws {
         let console = TestConsole()
         let group = TestGroup()
         let input = CommandInput(arguments: ["vapor", "sup"])
         XCTAssertThrowsError(try console.run(group, input: input), "Unknown command is supposed to throw") { error in
+            guard case .unknownCommand = error as? CommandError else {
+                return XCTFail("Expected `.unknownCommand` error, got \(error).")
+            }
             XCTAssertEqual((error as! CommandError).description, """
             Error: Unknown command `sup`
 
@@ -17,15 +32,43 @@ class CommandErrorTests: XCTestCase {
         }
     }
     
-    func testUnknownWithoutSuggestionCommand() throws {
+    func testUnknownCommandWithoutSuggestion() throws {
         let console = TestConsole()
         let group = TestGroup()
         let input = CommandInput(arguments: ["vapor", "desoxyribonucleic-acid"])
         XCTAssertThrowsError(try console.run(group, input: input), "Unknown command is supposed to throw") { error in
+            guard case .unknownCommand = error as? CommandError else {
+                return XCTFail("Expected `.unknownCommand` error, got \(error).")
+            }
             XCTAssertEqual((error as! CommandError).description, """
             Error: Unknown command `desoxyribonucleic-acid`
             """)
         }
+    }
+    
+    func testCommandWithMissingRequiredArgument() throws {
+        // TODO: Implement
+    }
+    
+    func testCommandWithInvalidArgumentType() throws {
+        let console = TestConsole()
+        let command = StrictCommand()
+
+        var input = CommandInput(arguments: ["vapor", "3", "true"])
+        try console.run(command, input: input)
+
+        input = CommandInput(arguments: ["vapor", "e", "true"])
+        try XCTAssertThrowsError(console.run(command, input: input))
+        XCTAssertThrowsError(try console.run(command, input: input), "Missing command is supposed to throw") { error in
+            guard case .invalidArgumentType = error as? CommandError else {
+                return XCTFail("Expected `.invalidArgumentType` error, got \(error).")
+            }
+            XCTAssertEqual((error as! CommandError).description, "Error: Could not convert argument for number to Int")
+        }
+    }
+    
+    func testCommandWithInvalidOptionType() throws {
+        // TODO: Implement
     }
     
     func testLevenshteinDistance() {

--- a/Tests/ConsoleKitTests/XCTestManifests.swift
+++ b/Tests/ConsoleKitTests/XCTestManifests.swift
@@ -6,9 +6,13 @@ extension CommandErrorTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__CommandErrorTests = [
+        ("testCommandWithInvalidArgumentType", testCommandWithInvalidArgumentType),
+        ("testCommandWithInvalidOptionType", testCommandWithInvalidOptionType),
+        ("testCommandWithMissingRequiredArgument", testCommandWithMissingRequiredArgument),
         ("testLevenshteinDistance", testLevenshteinDistance),
-        ("testUnknownWithoutSuggestionCommand", testUnknownWithoutSuggestionCommand),
-        ("testUnknownWithSuggestionCommand", testUnknownWithSuggestionCommand),
+        ("testMissingCommand", testMissingCommand),
+        ("testUnknownCommandWithoutSuggestion", testUnknownCommandWithoutSuggestion),
+        ("testUnknownCommandWithSuggestion", testUnknownCommandWithSuggestion),
     ]
 }
 


### PR DESCRIPTION
As discussed, this changes CommandError from being a struct to an enum.

The naming of the cases is a bit iffy, and I'll happily change those to better names.