### PR TITLE
Allow Checking to See if a Option is Present in the Command Call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,19 +7,19 @@ jobs:
       image: swift:5.1-xenial
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: swift test
   bionic:
     container: 
       image: swift:5.1-bionic
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: swift test
   thread:
     container: 
       image: swift:5.1-bionic
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: swift test --sanitize=thread

--- a/Sources/ConsoleKit/Command/Argument.swift
+++ b/Sources/ConsoleKit/Command/Argument.swift
@@ -33,18 +33,25 @@ public final class Argument<Value>: AnyArgument
     /// The argument's help text when `--help` is passed in.
     public let help: String
 
-    var value: Value?
+    var value: InputValue<Value>
 
     public var projectedValue: Argument<Value> {
         return self
     }
 
+    public var initialized: Bool {
+        switch self.value {
+        case .initialized: return true
+        case .uninitialized: return false
+        }
+    }
+
     /// @propertyWrapper value
     public var wrappedValue: Value {
-        guard let value = self.value else {
-            fatalError("Argument \(self.name) was not initialized")
+        switch self.value {
+        case let .initialized(value): return value
+        case .uninitialized: fatalError("Argument \(self.name) was not initialized")
         }
-        return value
     }
     
     /// Creates a new `Argument`
@@ -57,6 +64,7 @@ public final class Argument<Value>: AnyArgument
     public init(name: String, help: String = "") {
         self.name = name
         self.help = help
+        self.value = .uninitialized
     }
 
     func load(from input: inout CommandInput) throws {
@@ -66,6 +74,6 @@ public final class Argument<Value>: AnyArgument
         guard let value = Value(argument) else {
             throw CommandError.invalidArgumentType(self.name, type: Value.self)
         }
-        self.value = value
+        self.value = .initialized(value)
     }
 }

--- a/Sources/ConsoleKit/Command/CommandInput.swift
+++ b/Sources/ConsoleKit/Command/CommandInput.swift
@@ -42,13 +42,20 @@ public struct CommandInput {
         }
         // ensure there is a value after this index
         let valueIndex = self.arguments.index(after: flagIndex)
-        guard valueIndex <= self.arguments.endIndex else {
+        guard valueIndex < self.arguments.endIndex else {
             return (nil, true)
         }
 
         let value = self.arguments[valueIndex]
-        self.arguments.removeSubrange(flagIndex...valueIndex)
-        return (value, true)
+        switch value.first {
+        case "-": return (nil, true)
+        case "\\":
+            self.arguments.removeSubrange(flagIndex...valueIndex)
+            return (String(value.dropFirst()), true)
+        default:
+            self.arguments.removeSubrange(flagIndex...valueIndex)
+            return (value, true)
+        }
     }
 
     private func nextFlagIndex(name: String, short: Character?) -> Array<String>.Index? {

--- a/Sources/ConsoleKit/Command/CommandInput.swift
+++ b/Sources/ConsoleKit/Command/CommandInput.swift
@@ -36,19 +36,19 @@ public struct CommandInput {
         return true
     }
 
-    mutating func nextOption(name: String, short: Character?) -> String? {
+    mutating func nextOption(name: String, short: Character?) -> (value: String?, passedIn: Bool) {
         guard let flagIndex = self.nextFlagIndex(name: name, short: short) else {
-            return nil
+            return (nil, false)
         }
         // ensure there is a value after this index
         let valueIndex = self.arguments.index(after: flagIndex)
         guard valueIndex <= self.arguments.endIndex else {
-            return nil
+            return (nil, true)
         }
 
         let value = self.arguments[valueIndex]
         self.arguments.removeSubrange(flagIndex...valueIndex)
-        return value
+        return (value, true)
     }
 
     private func nextFlagIndex(name: String, short: Character?) -> Array<String>.Index? {

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -41,9 +41,16 @@ extension CommandSignature {
     }
 }
 
+enum InputValue<T> {
+    case initialized(T)
+    case uninitialized
+}
+
 internal protocol AnySignatureValue: class {
     var help: String { get }
     var name: String { get }
+    var initialized: Bool { get }
+
     func load(from input: inout CommandInput) throws
 }
 

--- a/Sources/ConsoleKit/Command/Flag.swift
+++ b/Sources/ConsoleKit/Command/Flag.swift
@@ -13,18 +13,25 @@ public final class Flag: AnyFlag {
     /// The option's help text when `--help` is passed in.
     public let short: Character?
 
+    public var initialized: Bool {
+        switch self.value {
+        case .initialized: return true
+        case .uninitialized: return false
+        }
+    }
+
     public var projectedValue: Flag {
         return self
     }
 
     public var wrappedValue: Bool {
-        guard let value = self.value else {
-            fatalError("Flag \(self.name) was not initialized")
+        switch self.value {
+        case let .initialized(value): return value
+        case .uninitialized: fatalError("Flag \(self.name) was not initialized")
         }
-        return value
     }
 
-    var value: Bool?
+    var value: InputValue<Bool>
 
     /// Creates a new `Option` with the `optionType` set to `.value`.
     ///
@@ -42,9 +49,10 @@ public final class Flag: AnyFlag {
         self.name = name
         self.short = short
         self.help = help
+        self.value = .uninitialized
     }
 
     func load(from input: inout CommandInput) throws {
-        self.value = input.nextFlag(name: self.name, short: self.short)
+        self.value = .initialized(input.nextFlag(name: self.name, short: self.short))
     }
 }

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -17,7 +17,7 @@ public final class Option<Value>: AnyOption
 
     /// Wheather the option was passed into the command's signature or not.
     ///
-    ///     app command --option
+    ///     app command --option "Hello World"
     ///     // signature.option.used == true
     ///
     ///     app command

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -19,14 +19,21 @@ public final class Option<Value>: AnyOption
         return self
     }
 
-    public var wrappedValue: Value? {
-        guard let value = self.value else {
-            fatalError("Option \(self.name) was not initialized")
+    public var initialized: Bool {
+        switch self.value {
+        case .initialized: return true
+        case .uninitialized: return false
         }
-        return value
     }
 
-    var value: Value??
+    public var wrappedValue: Value? {
+        switch self.value {
+        case let .initialized(value): return value
+        case .uninitialized: fatalError("Option \(self.name) was not initialized")
+        }
+    }
+
+    var value: InputValue<Value?>
     
     /// Creates a new `Option` with the `optionType` set to `.value`.
     ///
@@ -44,6 +51,7 @@ public final class Option<Value>: AnyOption
         self.name = name
         self.short = short
         self.help = help
+        self.value = .uninitialized
     }
 
     func load(from input: inout CommandInput) throws {
@@ -51,9 +59,9 @@ public final class Option<Value>: AnyOption
             guard let value = Value(option) else {
                 throw CommandError.invalidOptionType(self.name, type: Value.self)
             }
-            self.value = value
+            self.value = .initialized(value)
         } else {
-            self.value = .some(.none)
+            self.value = .initialized(nil)
         }
     }
 }

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -18,11 +18,11 @@ public final class Option<Value>: AnyOption
     /// Wheather the option was passed into the command's signature or not.
     ///
     ///     app command --option "Hello World"
-    ///     // signature.option.used == true
+    ///     // signature.option.isPresent == true
     ///
     ///     app command
-    ///     // signature.option.used == false
-    public private(set) var used: Bool
+    ///     // signature.option.isPresent == false
+    public private(set) var isPresent: Bool
 
     public var projectedValue: Option<Value> {
         return self
@@ -60,13 +60,13 @@ public final class Option<Value>: AnyOption
         self.name = name
         self.short = short
         self.help = help
-        self.used = false
+        self.isPresent = false
         self.value = .uninitialized
     }
 
     func load(from input: inout CommandInput) throws {
         let option = input.nextOption(name: self.name, short: self.short)
-        self.used = option.passedIn
+        self.isPresent = option.passedIn
 
         if let rawValue = option.value {
             guard let value = Value(rawValue) else {

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -15,6 +15,15 @@ public final class Option<Value>: AnyOption
     /// The option's help text when `--help` is passed in.
     public let short: Character?
 
+    /// Wheather the option was passed into the command's signature or not.
+    ///
+    ///     app command --option
+    ///     // signature.option.used == true
+    ///
+    ///     app command
+    ///     // signature.option.used == false
+    public private(set) var used: Bool
+
     public var projectedValue: Option<Value> {
         return self
     }
@@ -51,12 +60,16 @@ public final class Option<Value>: AnyOption
         self.name = name
         self.short = short
         self.help = help
+        self.used = false
         self.value = .uninitialized
     }
 
     func load(from input: inout CommandInput) throws {
-        if let option = input.nextOption(name: self.name, short: self.short) {
-            guard let value = Value(option) else {
+        let option = input.nextOption(name: self.name, short: self.short)
+        self.used = option.passedIn
+
+        if let rawValue = option.value {
+            guard let value = Value(rawValue) else {
                 throw CommandError.invalidOptionType(self.name, type: Value.self)
             }
             self.value = .initialized(value)

--- a/Tests/ConsoleKitTests/CommandTests.swift
+++ b/Tests/ConsoleKitTests/CommandTests.swift
@@ -93,4 +93,40 @@ class CommandTests: XCTestCase {
         let input = CommandInput(arguments: ["vapor", "true", "--count", "42"])
         try console.run(command, input: input)
     }
+
+    func testOptionUsed() throws {
+        struct OptionInitialized: Command {
+            struct Signature: CommandSignature {
+                @Option(name: "option") var option: Bool?
+            }
+
+            var help: String = ""
+
+            func run(using context: CommandContext, signature: OptionInitialized.Signature) throws {
+                XCTAssert(signature.$option.used)
+            }
+        }
+
+        struct OptionUninitialized: Command {
+            struct Signature: CommandSignature {
+                @Option(name: "option") var option: Bool?
+            }
+
+            var help: String = ""
+
+            func run(using context: CommandContext, signature: OptionUninitialized.Signature) throws {
+                XCTAssertFalse(signature.$option.used)
+            }
+        }
+
+        let console = TestConsole()
+        let initialized = OptionInitialized()
+        let uninitialized = OptionUninitialized()
+
+        let initializedInput = CommandInput(arguments: ["vapor", "--option", "true"])
+        try console.run(initialized, input: initializedInput)
+
+        let uninitializedInput = CommandInput(arguments: ["vapor"])
+        try console.run(uninitialized, input: uninitializedInput)
+    }
 }

--- a/Tests/ConsoleKitTests/CommandTests.swift
+++ b/Tests/ConsoleKitTests/CommandTests.swift
@@ -106,7 +106,7 @@ class CommandTests: XCTestCase {
 
             func run(using context: CommandContext, signature: OptionInitialized.Signature) throws {
                 assertion(signature)
-                XCTAssert(signature.$option.used)
+                XCTAssert(signature.$option.isPresent)
             }
         }
 
@@ -118,7 +118,7 @@ class CommandTests: XCTestCase {
             var help: String = ""
 
             func run(using context: CommandContext, signature: OptionUninitialized.Signature) throws {
-                XCTAssertFalse(signature.$option.used)
+                XCTAssertFalse(signature.$option.isPresent)
             }
         }
 


### PR DESCRIPTION
Adds a `.isPresent` property to the `Option` type that lets you check to see if the option was actually passed in when the command was called or not:

```
app command --option
// signature.option = nil
// signature.option.isPresent == true

app command
// signature.option = nil
// signature.option.isPresent == false
```

Look at that! We also don't have to pass in a value for an option any more. Because now we basically have a turnery value, (`nil`, `uninitialized`, `T()`), we need different ways of defining these states. So now you app can act differently based on whether the option is passed in or not.

There is also an `.initialized` property on all the signature value types. For now it doesn't really do you a whole lot, but it's something could be useful in the future so I decided to lay the groundwork for now.