### PR TITLE
testShortFlageNeedsToMatchExactly test case uses Optional Option(s)

### DIFF
--- a/Tests/ConsoleKitTests/CommandTests.swift
+++ b/Tests/ConsoleKitTests/CommandTests.swift
@@ -52,10 +52,10 @@ class CommandTests: XCTestCase {
     func testShortFlagNeedsToMatchExactly() throws {
         struct Signature: CommandSignature {
             @Option(name: "x-short", short: "x")
-            var xShort: String
+            var xShort: String?
             
             @Option(name: "y-short", short: "y")
-            var yShort: String
+            var yShort: String?
             
             init() { }
         }


### PR DESCRIPTION
  - Fixes test case regression introduced in #125