### PR TITLE
Make ConsoleText ExpressibleByStringInterpolation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: swift build
     - run: swift test --enable-test-discovery --sanitize=thread
   bionic:
     container: 
@@ -16,5 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: swift build
     - run: swift test --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: |
-      swift build
-      swift test --enable-test-discovery --sanitize=thread
+    - run: swift build
+    - run: swift test --enable-test-discovery --sanitize=thread
   bionic:
     container: 
       image: swift:5.1-bionic
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: |
-      swift build
-      swift test --enable-test-discovery --sanitize=thread
+    - run: swift build
+    - run: swift test --enable-test-discovery --sanitize=thread

--- a/Sources/ConsoleKit/Command/CommandGroup.swift
+++ b/Sources/ConsoleKit/Command/CommandGroup.swift
@@ -51,8 +51,8 @@ extension CommandGroup {
     }
 
     private func outputGroupHelp(using context: inout CommandContext) {
-        context.console.output("Usage: ".consoleText(.info) + context.input.executable.consoleText() + " ", newLine: false)
-        context.console.output("<command> ".consoleText(.warning), newLine: false)
+        context.console.output("\("Usage: ", style: .info) \(context.input.executable)", newLine: false)
+        context.console.output("\("<command>", style: .warning) ", newLine: false)
         context.console.print()
 
         if !self.help.isEmpty {

--- a/Sources/ConsoleKit/Output/ConsoleText.swift
+++ b/Sources/ConsoleKit/Output/ConsoleText.swift
@@ -96,3 +96,29 @@ public func +(lhs: ConsoleText, rhs: ConsoleText) -> ConsoleText {
 public func +=(lhs: inout ConsoleText, rhs: ConsoleText) {
     lhs = lhs + rhs
 }
+
+extension ConsoleText: ExpressibleByStringInterpolation {
+    public init(stringInterpolation: StringInterpolation) {
+        self.fragments = stringInterpolation.fragments
+    }
+
+    public struct StringInterpolation: StringInterpolationProtocol {
+        public var fragments: [ConsoleTextFragment]
+
+        public init(literalCapacity: Int, interpolationCount: Int) {
+            self.fragments = []
+            self.fragments.reserveCapacity(literalCapacity)
+        }
+
+        public mutating func appendLiteral(_ literal: String) {
+            self.fragments.append(.init(string: literal))
+        }
+
+        public mutating func appendInterpolation(
+            _ value: String,
+            style: ConsoleStyle = .plain
+        ) {
+            self.fragments.append(.init(string: value, style: style))
+        }
+    }
+}


### PR DESCRIPTION
Previously, to generate `ConsoleText` you had to append strings using `+` and `consoleText()`.

```swift
let name = "Vapor"
console.output("Hello " + name.consoleText())
```

Now, `ConsoleText` supports string interpolation. 

```swift
console.output("Hello \(name)")
```

String interpolation also allows you to pass an optional `style` parameter for adding colors.

```swift
console.output("Hello \(name, style: .info)")
```
