### PR TITLE
Shell Completion Code Generation

### DIFF
--- a/Sources/ConsoleKit/Command/AnyCommand.swift
+++ b/Sources/ConsoleKit/Command/AnyCommand.swift
@@ -8,7 +8,7 @@ public protocol AnyCommand {
     func outputAutoComplete(using context: inout CommandContext) throws
     func outputHelp(using context: inout CommandContext) throws
 
-    /// 
+    /// Renders the shell completion script functions for the command and any descendent subcommands.
     func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String
 }
 

--- a/Sources/ConsoleKit/Command/AnyCommand.swift
+++ b/Sources/ConsoleKit/Command/AnyCommand.swift
@@ -20,4 +20,8 @@ extension AnyCommand {
     public func outputHelp(using context: inout CommandContext) {
         // do nothing
     }
+
+    public func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String {
+        return ""
+    }
 }

--- a/Sources/ConsoleKit/Command/AnyCommand.swift
+++ b/Sources/ConsoleKit/Command/AnyCommand.swift
@@ -7,6 +7,8 @@ public protocol AnyCommand {
     func run(using context: inout CommandContext) throws
     func outputAutoComplete(using context: inout CommandContext) throws
     func outputHelp(using context: inout CommandContext) throws
+
+    func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String
 }
 
 extension AnyCommand {

--- a/Sources/ConsoleKit/Command/AnyCommand.swift
+++ b/Sources/ConsoleKit/Command/AnyCommand.swift
@@ -8,6 +8,7 @@ public protocol AnyCommand {
     func outputAutoComplete(using context: inout CommandContext) throws
     func outputHelp(using context: inout CommandContext) throws
 
+    /// 
     func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String
 }
 

--- a/Sources/ConsoleKit/Command/Argument.swift
+++ b/Sources/ConsoleKit/Command/Argument.swift
@@ -34,7 +34,7 @@ public final class Argument<Value>: AnyArgument
     public let help: String
 
     /// The argument's shell completion action.
-    public let completionAction: CompletionAction
+    public let completion: CompletionAction
 
     var value: InputValue<Value>
 
@@ -64,10 +64,10 @@ public final class Argument<Value>: AnyArgument
     ///
     /// - Parameters:
     ///   - help: The arguments's help text when `--help` is passed in.
-    public init(name: String, help: String = "", completionAction: CompletionAction = .default) {
+    public init(name: String, help: String = "", completion: CompletionAction = .default) {
         self.name = name
         self.help = help
-        self.completionAction = completionAction
+        self.completion = completion
         self.value = .uninitialized
     }
 

--- a/Sources/ConsoleKit/Command/Argument.swift
+++ b/Sources/ConsoleKit/Command/Argument.swift
@@ -33,6 +33,9 @@ public final class Argument<Value>: AnyArgument
     /// The argument's help text when `--help` is passed in.
     public let help: String
 
+    /// The argument's shell completion action.
+    public let completionAction: CompletionAction
+
     var value: InputValue<Value>
 
     public var projectedValue: Argument<Value> {
@@ -61,9 +64,10 @@ public final class Argument<Value>: AnyArgument
     ///
     /// - Parameters:
     ///   - help: The arguments's help text when `--help` is passed in.
-    public init(name: String, help: String = "") {
+    public init(name: String, help: String = "", completionAction: CompletionAction = .default) {
         self.name = name
         self.help = help
+        self.completionAction = completionAction
         self.value = .uninitialized
     }
 

--- a/Sources/ConsoleKit/Command/Argument.swift
+++ b/Sources/ConsoleKit/Command/Argument.swift
@@ -34,6 +34,8 @@ public final class Argument<Value>: AnyArgument
     public let help: String
 
     /// The argument's shell completion action.
+    ///
+    /// See `CompletionAction` for more information and available actions.
     public let completion: CompletionAction
 
     var value: InputValue<Value>
@@ -63,7 +65,10 @@ public final class Argument<Value>: AnyArgument
     ///     var count: Int
     ///
     /// - Parameters:
+    ///   - name: The argument's identifying name.
     ///   - help: The arguments's help text when `--help` is passed in.
+    ///   - completion: The argument's shell completion action. See `CompletionAction` for more
+    ///                 information and available actions.
     public init(name: String, help: String = "", completion: CompletionAction = .default) {
         self.name = name
         self.help = help

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -52,6 +52,8 @@ internal protocol AnySignatureValue: class {
     var initialized: Bool { get }
 
     func load(from input: inout CommandInput) throws
+
+    func completionExpression(for shell: Shell) -> String
 }
 
 internal protocol AnyArgument: AnySignatureValue { }

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -49,17 +49,34 @@ enum InputValue<T> {
 internal protocol AnySignatureValue: class {
     var help: String { get }
     var name: String { get }
+    var short: Character? { get }
     var initialized: Bool { get }
 
-    func load(from input: inout CommandInput) throws
+    var hasLabel: Bool { get }
 
     func completionExpression(for shell: Shell) -> String
+
+    func load(from input: inout CommandInput) throws
+}
+
+extension AnySignatureValue {
+
+    var hasLabel: Bool { true }
+
+    var labels: [String] {
+        guard self.hasLabel else { return [] }
+        let long = "--\(self.name)"
+        guard let short = self.short.map({ "-\($0)" }) else { return [long] }
+        return [long, short]
+    }
 }
 
 internal protocol AnyArgument: AnySignatureValue { }
-internal protocol AnyOption: AnySignatureValue {
-    var short: Character? { get }
+
+extension AnyArgument {
+    var short: Character? { nil }
+    var hasLabel: Bool { false }
 }
-internal protocol AnyFlag: AnySignatureValue {
-    var short: Character? { get }
-}
+
+internal protocol AnyOption: AnySignatureValue { }
+internal protocol AnyFlag: AnySignatureValue { }

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -49,34 +49,17 @@ enum InputValue<T> {
 internal protocol AnySignatureValue: class {
     var help: String { get }
     var name: String { get }
-    var short: Character? { get }
     var initialized: Bool { get }
 
-    var hasLabel: Bool { get }
-
-    func completionExpression(for shell: Shell) -> String
-
     func load(from input: inout CommandInput) throws
-}
 
-extension AnySignatureValue {
-
-    var hasLabel: Bool { true }
-
-    var labels: [String] {
-        guard self.hasLabel else { return [] }
-        let long = "--\(self.name)"
-        guard let short = self.short.map({ "-\($0)" }) else { return [long] }
-        return [long, short]
-    }
+    var completionInfo: CompletionArgumentInfo { get }
 }
 
 internal protocol AnyArgument: AnySignatureValue { }
-
-extension AnyArgument {
-    var short: Character? { nil }
-    var hasLabel: Bool { false }
+internal protocol AnyOption: AnySignatureValue {
+    var short: Character? { get }
 }
-
-internal protocol AnyOption: AnySignatureValue { }
-internal protocol AnyFlag: AnySignatureValue { }
+internal protocol AnyFlag: AnySignatureValue {
+    var short: Character? { get }
+}

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -53,7 +53,9 @@ internal protocol AnySignatureValue: class {
 
     func load(from input: inout CommandInput) throws
 
-    var completionInfo: CompletionArgumentInfo { get }
+    /// Returns the information used by the completion-generation code to provide
+    /// shell completions for command signature values and their arguments.
+    var completionInfo: CompletionSignatureValueInfo { get }
 }
 
 internal protocol AnyArgument: AnySignatureValue { }

--- a/Sources/ConsoleKit/Command/Commands.swift
+++ b/Sources/ConsoleKit/Command/Commands.swift
@@ -7,6 +7,13 @@ public struct Commands {
     public var defaultCommand: AnyCommand?
 
     /// If `true`, an `autocomplete` subcommand will be added to any created `CommandGroup`.
+    ///
+    /// The `autocomplete` command generates shell completion scripts that can be loaded from shell configuration
+    /// files to provide autocompletion for the entire command hierarchy and its command-line arguments.
+    ///
+    /// - Important: `enableAutocomplete` should only be set to `true` for a _root_ command group. Any nested
+    ///   subcommands will automatically be included in the completion script generation process.
+    ///
     public var enableAutocomplete: Bool
 
     /// Creates a new `ConfiguredCommands` struct. This is usually done by calling `resolve(for:)` on `Commands`.
@@ -14,7 +21,14 @@ public struct Commands {
     /// - parameters:
     ///     - commands: Top-level available commands, stored by unique name.
     ///     - defaultCommand: If set, this is the default top-level command that should run if no other commands are specified.
-    ///     - autocomplete: If `true`, an `autocomplete` subcommand will be added to any created `CommandGroup`.
+    ///     - enableAutocomplete: If `true`, an `autocomplete` subcommand will be added to any created `CommandGroup`.
+    ///
+    ///       The `autocomplete` command generates shell completion scripts that can be loaded from shell configuration
+    ///       files to provide autocompletion for the entire command hierarchy and its command-line arguments.
+    ///
+    ///       `enableAutocomplete` should only be set to `true` for a _root_ command group. Any nested subcommands will
+    ///       automatically be included in the completion script generation process.
+    ///
     public init(commands: [String: AnyCommand] = [:], defaultCommand: AnyCommand? = nil, enableAutocomplete: Bool = false) {
         self.commands = commands
         self.defaultCommand = defaultCommand

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -407,7 +407,7 @@ extension CommandInput {
     /// like `".build/x86_64-apple-macosx/debug/program"`; `executableName` will return
     /// `"program"`.
     ///
-    fileprivate var executableName: String {
+    var executableName: String {
         return String(self.executablePath.first!.split(separator: "/").last!)
     }
 

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -85,7 +85,7 @@ extension AnyCommand {
         """ : ""
         )\( !arguments.isEmpty ? """
 
-            if [[ $COMP_CWORD != \(commandDepth) ]]; then
+            if [[ "$COMP_CWORD" -ne \(commandDepth) ]]; then
                 case $prev in
         \( arguments.map { argument in
             let label = argument.labels?.values.joined(separator: "|") ?? "*"
@@ -113,12 +113,12 @@ extension AnyCommand {
         """ : ""
         )\( !subcommands.isEmpty ? """
 
-            if [[ $COMP_CWORD != \(commandDepth) ]]; then
+            if [[ "$COMP_CWORD" -ne \(commandDepth) ]]; then
                 case ${COMP_WORDS[\(commandDepth)]} in
         \( subcommands.map { (name, _) in
             return """
                     \(name))
-                        \(context.input.completionFunctionName(forSubcommand: name)) \(commandDepth + 1)
+                        \(context.input.completionFunctionName(forSubcommand: name))
                         return
                         ;;
         """

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -1,7 +1,16 @@
 /// Shell completion implementations.
-public enum Shell {
+public enum Shell: String, LosslessStringConvertible, CaseIterable {
+
     case bash
     case zsh
+
+    // See `CustomStringConvertible`.
+    public var description: String { self.rawValue }
+
+    // See `LosslessStringConvertible`.
+    public init?(_ description: String) {
+        self.init(rawValue: description)
+    }
 }
 
 extension AnyCommand {

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -448,6 +448,6 @@ extension StringProtocol {
             .replacingOccurrences(of: "}", with: "\\}")
             .replacingOccurrences(of: "[", with: "\\[")
             .replacingOccurrences(of: "]", with: "\\]")
-            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\n", with: " ")
     }
 }

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -1,0 +1,227 @@
+/// Shell completion implementations.
+public enum Shell {
+    case zsh
+}
+
+extension AnyCommand {
+
+    /// Returns the complete contents of a completion file appropriate for the given
+    /// `shell` for `self` and, recursively, al of its descendent subcommands.
+    public func renderCompletionFile(using context: CommandContext, shell: Shell) -> String {
+        switch shell {
+        case .zsh:
+            return self.renderZshCompletionFile(using: context)
+        }
+    }
+}
+
+extension Command {
+
+    // See `AnyCommand`.
+    public func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String {
+        switch shell {
+        case .zsh:
+            return self.renderZshCompletionFunction(using: context, signatureValues: Signature.reference.values)
+        }
+    }
+}
+
+extension CommandGroup {
+
+    // See `AnyCommand`.
+    public func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String {
+        var functions: [String] = []
+        switch shell {
+        case .zsh:
+            functions.append(self.renderZshCompletionFunction(using: context, subcommands: self.commands))
+        }
+        for (name, command) in self.commands.sorted(by: { $0.key < $1.key }) {
+            var context = context
+            context.input.executablePath.append(name)
+            functions.append(command.renderCompletionFunctions(using: context, shell: shell))
+        }
+        return functions.joined(separator: "\n")
+    }
+}
+
+extension AnyCommand {
+
+    /// Returns the contents of a zsh completion file for `self` and, recursively,
+    /// all of its descendent subcommands.
+    fileprivate func renderZshCompletionFile(using context: CommandContext) -> String {
+        return """
+        #compdef \(context.input.executableName)
+
+        local context state state_descr line
+        typeset -A opt_args
+
+        \(self.renderCompletionFunctions(using: context, shell: .zsh))
+        _\(context.input.executableName)
+
+        """
+    }
+
+    /// Returns the zsh completion function for `self`.
+    ///
+    /// - Parameters:
+    ///   - context: The command context to use to generate the function name.
+    ///   - signatureValues: The signature values to use to generate the argument completions.
+    ///   - subcommands: The subcommands to use to generate the subcommand completions.
+    ///
+    fileprivate func renderZshCompletionFunction(
+        using context: CommandContext,
+        signatureValues: [AnySignatureValue] = [],
+        subcommands: [String: AnyCommand] = [:]
+    ) -> String {
+        let signatureValues = signatureValues.sorted(by: { $0.name < $1.name })
+        let subcommands = subcommands.sorted(by: { $0.key < $1.key })
+        return """
+        \(context.input.completionFunctionName())() {
+            arguments=(
+        \(([Flag.help] + signatureValues).map {
+            return """
+                \($0.completionExpression(for: .zsh))
+        """
+        }.joined(separator: "\n"))\(!subcommands.isEmpty ? """
+
+                '(-): :->command'
+                '(-)*:: :->arg'
+        """ : "")
+            )
+            _arguments -C $arguments && return\(!subcommands.isEmpty ? """
+
+            case $state in
+                (command)
+                    local subcommands
+                    subcommands=(
+        \(subcommands.map { (name, command) in
+            return """
+                        "\(name):\(command.help.completionEscaped)"
+        """
+        }.joined(separator: "\n"))
+                    )
+                    _describe "subcommand" subcommands
+                    ;;
+                (arg)
+                    case ${words[1]} in
+        \(subcommands.map { (name, _) in
+            return """
+                        (\(name))
+                            \(context.input.completionFunctionName(forSubcommand: name))
+                            ;;
+        """
+        }.joined(separator: "\n"))
+                    esac
+                    ;;
+            esac
+        """ : ""
+        )
+        }
+
+        """
+    }
+}
+
+extension Flag {
+
+    /// A generic `--help` flag added to every command's completion.
+    fileprivate static var help: Flag {
+        return Flag(name: "help", short: "h", help: "Show more information about this command")
+    }
+
+    // See `AnySignatureValue`.
+    func completionExpression(for shell: Shell) -> String {
+        switch shell {
+        case .zsh:
+            let long = "--\(self.name)"
+            let help = self.help.completionEscaped
+            if let short = self.short.map({ "-\($0)" }) {
+                return "\"(\(long) \(short))\"{\(long),\(short)}\"[\(help)]\""
+            } else {
+                return "\"\(long)[\(help)]\""
+            }
+        }
+    }
+}
+
+extension Option {
+
+    // See `AnySignatureValue`.
+    func completionExpression(for shell: Shell) -> String {
+        switch shell {
+        case .zsh:
+            let long = "--\(self.name)"
+            let help = self.help.completionEscaped
+            if let short = self.short.map({ "-\($0)" }) {
+                return "\"(\(long) \(short))\"{\(long),\(short)}\"[\(help)]: : \""
+            } else {
+                return "\"\(long)[\(help)]: : \""
+            }
+        }
+    }
+}
+
+extension Argument {
+
+    // See `AnySignatureValue`.
+    func completionExpression(for shell: Shell) -> String {
+        switch shell {
+        case .zsh:
+            return "\":\(self.help.completionEscaped): \""
+        }
+    }
+}
+
+extension CommandInput {
+
+    /// Returns the filename of the executable.
+    ///
+    /// For example, if the executable named `program` is run from the package's root
+    /// via `swift run program`, the first element in `executablePath` will be something
+    /// like `".build/x86_64-apple-macosx/debug/program"`; `executableName` will return
+    /// `"program"`.
+    ///
+    fileprivate var executableName: String {
+        return String(self.executablePath.first!.split(separator: "/").last!)
+    }
+
+    /// Returns the name to use for the completion function for the current `executablePath`.
+    ///
+    /// - Parameter subcommand: An optional subcommand name to append to the `executablePath`.
+    ///
+    /// For example, if the current `executablePath` is
+    ///
+    ///     [".build/x86_64-apple-macosx/debug/program", "subcommand1", "subcommand2"]
+    ///
+    /// the function name returned is `_program_subcommand1_subcommand2`.
+    ///
+    fileprivate func completionFunctionName(forSubcommand subcommand: String? = nil) -> String {
+        var components: [String] = [self.executableName]
+        if self.executablePath.count > 1 {
+            components.append(contentsOf: self.executablePath[1...])
+        }
+        if let subcommand = subcommand {
+            components.append(subcommand)
+        }
+        return "_" + components.joined(separator: "_")
+    }
+}
+
+extension StringProtocol {
+
+    /// Returns a copy of `self` with any characters that might cause trouble
+    /// in a completion script escaped.
+    fileprivate var completionEscaped: String {
+        return self
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "`", with: "\\`")
+            .replacingOccurrences(of: "(", with: "\\(")
+            .replacingOccurrences(of: ")", with: "\\)")
+            .replacingOccurrences(of: "{", with: "\\{")
+            .replacingOccurrences(of: "}", with: "\\}")
+            .replacingOccurrences(of: "[", with: "\\[")
+            .replacingOccurrences(of: "]", with: "\\]")
+            .replacingOccurrences(of: "\n", with: "\\n")
+    }
+}

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -15,6 +15,9 @@ public final class Option<Value>: AnyOption
     /// The option's help text when `--help` is passed in.
     public let short: Character?
 
+    /// The option's shell completion action.
+    public let completionAction: CompletionAction
+
     /// Wheather the option was passed into the command's signature or not.
     ///
     ///     app command --option "Hello World"
@@ -55,11 +58,13 @@ public final class Option<Value>: AnyOption
     public init(
         name: String,
         short: Character? = nil,
-        help: String = ""
+        help: String = "",
+        completionAction: CompletionAction = .default
     ) {
         self.name = name
         self.short = short
         self.help = help
+        self.completionAction = completionAction
         self.isPresent = false
         self.value = .uninitialized
     }

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -16,6 +16,8 @@ public final class Option<Value>: AnyOption
     public let short: Character?
 
     /// The option's shell completion action.
+    ///
+    /// See `CompletionAction` for more information and available actions.
     public let completion: CompletionAction
 
     /// Wheather the option was passed into the command's signature or not.
@@ -53,8 +55,11 @@ public final class Option<Value>: AnyOption
     ///     var verbose: Bool?
     ///
     /// - Parameters:
+    ///   - name: The option's identifying name that can be passed in to the command call.
     ///   - short: The short-hand for the flag that can be passed in to the command call.
     ///   - help: The option's help text when `--help` is passed in.
+    ///   - completion: The option's shell completion action. See `CompletionAction` for more
+    ///                 information and available actions.
     public init(
         name: String,
         short: Character? = nil,

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -16,7 +16,7 @@ public final class Option<Value>: AnyOption
     public let short: Character?
 
     /// The option's shell completion action.
-    public let completionAction: CompletionAction
+    public let completion: CompletionAction
 
     /// Wheather the option was passed into the command's signature or not.
     ///
@@ -59,12 +59,12 @@ public final class Option<Value>: AnyOption
         name: String,
         short: Character? = nil,
         help: String = "",
-        completionAction: CompletionAction = .default
+        completion: CompletionAction = .default
     ) {
         self.name = name
         self.short = short
         self.help = help
-        self.completionAction = completionAction
+        self.completion = completion
         self.isPresent = false
         self.value = .uninitialized
     }

--- a/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
@@ -16,7 +16,7 @@ struct GenerateAutocompleteCommand: Command {
             name: "shell",
             short: "s",
             help: """
-            Generate completion script for SHELL [ \(Shell.allCases.map { "\($0)" }.joined(separator: " | ")) ].
+            Generate a completion script for SHELL [ \(Shell.allCases.map { "\($0)" }.joined(separator: " | ")) ].
             Defaults to the "SHELL" environment variable if possible.
             """,
             completion: .values(of: Shell.self)
@@ -27,26 +27,53 @@ struct GenerateAutocompleteCommand: Command {
             name: "output",
             short: "o",
             help: """
-            Write output to file at OUTPUT.
+            Write the completion script to the file at OUTPUT, overwriting its contents.
             Defaults to printing to stdout.
             """,
             completion: .files()
         )
         var output: String?
+
+        @Flag(name: "quiet", short: "q", help: "Suppress any informational console output")
+        var quiet: Bool
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
+
         guard let rootCommand = self.rootCommand else { fatalError("`rootCommand` was not initialized") }
         guard let shell = signature.shell ?? self.environmentShell() else {
             throw CommandError.missingRequiredArgument(signature.$shell.name)
         }
+
         // Reset the executable path
         var context = context
         context.input.executablePath = [context.input.executablePath.first!]
+
         let script = rootCommand.renderCompletionScript(using: context, shell: shell)
+
         if let output = signature.output, let contents = script.data(using: .utf8) {
-            try contents.write(to: URL(fileURLWithPath: output))
-            context.console.info("\n\(shell) completion script written to \(output)")
+            let outputUrl = URL(fileURLWithPath: output)
+            try contents.write(to: outputUrl)
+            guard !signature.quiet else { return }
+            context.console.info("\(shell) completion script written to `\(output)`")
+            switch shell {
+            case .bash:
+                context.console.info("Add the following line to your `~/.bashrc` or `~/.bash_profile` to enable autocompletion:")
+                context.console.output("[ -f \"\(output)\" ] && . \"\(output)\"", style: .plain)
+            case .zsh:
+                let filename = outputUrl.lastPathComponent
+                let expectedFilename = "_\(context.input.executableName)"
+                if filename != expectedFilename {
+                    context.console.warning(
+                        "Note: The zsh completion script should be named `\(expectedFilename)` to be registered by `compinit`"
+                    )
+                }
+                let directory = outputUrl.deletingLastPathComponent().path
+                context.console.info(
+                    "Add the following line to your `~/.zshrc` to add the `\(directory)` directory to your `fpath`:"
+                )
+                context.console.output("fpath=(\"\(directory)\" $fpath)", style: .plain)
+            }
         } else {
             context.console.output(script, style: .plain)
         }

--- a/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
@@ -15,9 +15,10 @@ struct GenerateAutocompleteCommand: Command {
         @Option(
             name: "shell",
             short: "s",
-            help: "Generate completion script for SHELL [ \(Shell.allCases.map { "\($0)" }.joined(separator: " | ")) ]. \n"
-                + "Defaults to the \"SHELL\" environment variable if possible."
-            ,
+            help: """
+            Generate completion script for SHELL [ \(Shell.allCases.map { "\($0)" }.joined(separator: " | ")) ].
+            Defaults to the "SHELL" environment variable if possible.
+            """,
             completion: .values(of: Shell.self)
         )
         var shell: Shell?
@@ -25,8 +26,10 @@ struct GenerateAutocompleteCommand: Command {
         @Option(
             name: "output",
             short: "o",
-            help: "Write output to file at OUTPUT. \n"
-                + "Defaults to printing to stdout.",
+            help: """
+            Write output to file at OUTPUT.
+            Defaults to printing to stdout.
+            """,
             completion: .files()
         )
         var output: String?

--- a/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct GenerateAutocompleteCommand: Command {
+
+    var help: String { "Generate shell completion scripts for the executable" }
+
+    var rootCommand: AnyCommand?
+
+    init(rootCommand: AnyCommand? = nil) {
+        self.rootCommand = rootCommand
+    }
+
+    struct Signature: CommandSignature {
+
+        @Argument(
+            name: "shell",
+            help: "The shell to target (\(Shell.allCases.map { "\($0)" }.joined(separator: "|")))",
+            completion: .values(of: Shell.self)
+        )
+        var shell: Shell
+    }
+
+    func run(using context: CommandContext, signature: Signature) throws {
+        guard let rootCommand = self.rootCommand else { fatalError("`rootCommand` was not initialized") }
+        // Reset the executable path
+        var context = context
+        context.input.executablePath = [context.input.executablePath.first!]
+        let script = rootCommand.renderCompletionScript(using: context, shell: signature.shell)
+        context.console.output(script, style: .plain)
+    }
+}

--- a/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
@@ -12,20 +12,50 @@ struct GenerateAutocompleteCommand: Command {
 
     struct Signature: CommandSignature {
 
-        @Argument(
+        @Option(
             name: "shell",
-            help: "The shell to target (\(Shell.allCases.map { "\($0)" }.joined(separator: "|")))",
+            short: "s",
+            help: "Generate completion script for SHELL [ \(Shell.allCases.map { "\($0)" }.joined(separator: " | ")) ]. \n"
+                + "Defaults to the \"SHELL\" environment variable if possible."
+            ,
             completion: .values(of: Shell.self)
         )
-        var shell: Shell
+        var shell: Shell?
+
+        @Option(
+            name: "output",
+            short: "o",
+            help: "Write output to file at OUTPUT. \n"
+                + "Defaults to printing to stdout.",
+            completion: .files()
+        )
+        var output: String?
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
         guard let rootCommand = self.rootCommand else { fatalError("`rootCommand` was not initialized") }
+        guard let shell = signature.shell ?? self.environmentShell() else {
+            throw CommandError.missingRequiredArgument(signature.$shell.name)
+        }
         // Reset the executable path
         var context = context
         context.input.executablePath = [context.input.executablePath.first!]
-        let script = rootCommand.renderCompletionScript(using: context, shell: signature.shell)
-        context.console.output(script, style: .plain)
+        let script = rootCommand.renderCompletionScript(using: context, shell: shell)
+        if let output = signature.output, let contents = script.data(using: .utf8) {
+            try contents.write(to: URL(fileURLWithPath: output))
+            context.console.info("\n\(shell) completion script written to \(output)")
+        } else {
+            context.console.output(script, style: .plain)
+        }
+    }
+
+    /// Returns a `Shell` value created from the process's environment variable `"SHELL"`.
+    private func environmentShell() -> Shell? {
+        guard
+            let shellPath = ProcessInfo.processInfo.environment["SHELL"],
+            let shellName = shellPath.split(separator: "/").last,
+            let shell = Shell(rawValue: String(shellName))
+            else { return nil }
+        return shell
     }
 }

--- a/Sources/ConsoleKitExample/main.swift
+++ b/Sources/ConsoleKitExample/main.swift
@@ -5,7 +5,7 @@ let console: Console = Terminal()
 var input = CommandInput(arguments: CommandLine.arguments)
 var context = CommandContext(console: console, input: input)
 
-var commands = Commands()
+var commands = Commands(enableAutocomplete: true)
 commands.use(DemoCommand(), as: "demo", isDefault: false)
 
 do {
@@ -13,6 +13,6 @@ do {
         .group(help: "An example command-line application built with ConsoleKit")
     try console.run(group, input: input)
 } catch let error {
-    console.error(error.localizedDescription)
+    console.error("\(error)")
     exit(1)
 }


### PR DESCRIPTION
Implements shell completion script generation for `bash` and `zsh`, and adds a flag to `Commands` to use it right out of the box:

```swift
// main.swift

// ...
var commands = Commands(enableAutocomplete: true)
// ...
let group = commands.group(help: "My command-line application")
try console.run(group, using: input)
// ...
```

The `CommandGroup` created will have an `autocomplete` command (a `GenerateAutocompleteCommand`) that can be used to generate shell completion scripts for the entire command hierarchy and its command-line arguments:

```
Usage: <executable> autocomplete [--shell,-s] [--output,-o] [--quiet,-q]

Generate shell completion scripts for the executable

Options:
   shell Generate a completion script for SHELL [ bash | zsh ].
         Defaults to the "SHELL" environment variable if possible.
  output Write the completion script to the file at OUTPUT, overwriting its contents.
         Defaults to printing to stdout.

Flags:
   quiet Suppress any informational console output
```

`Option` and `Argument` signature values can optionally provide a `CompletionAction`. For example, in `GenerateAutocompleteCommand.Signature`:

```swift
@Option(
    name: "shell", 
    // ...
    completion: .values(of: Shell.self)
)
var shell: Shell?

@Option(
    name: "output",
    // ...
    completion: .files()
)
var output: String?
```

`CompletionAction` currently provides static factory methods for completing files (including directories), directories (excluding regular files), and a list of string values, as well as a convenience method for creating a list of values from a `CaseIterable` and `LosslessStringConvertible` type.