### PR TITLE
Error on unrecognized input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ Package.resolved
 .DS_Store
 DerivedData
 .swiftpm
+Tests/LinuxMain.swift
 

--- a/Sources/ConsoleKit/Command/Command.swift
+++ b/Sources/ConsoleKit/Command/Command.swift
@@ -86,6 +86,10 @@ public protocol Command: AnyCommand {
 extension Command {
     public func run(using context: inout CommandContext) throws {
         let signature = try Signature(from: &context.input)
+        guard context.input.arguments.isEmpty else {
+            let input = context.input.arguments.joined(separator: " ")
+            throw ConsoleError.init(identifier: "unknownInput", reason: "Input not recognized: \(input)")
+        }
         try self.run(using: context, signature: signature)
     }
 


### PR DESCRIPTION
Updates ConsoleKit to throw an error if unrecognized input is passed (#144). 

ConsoleKit currently ignores any input it is unable to parse. This makes simple typos confusing to debug, for example:

```sh
$ vapor run serve --port=1337
Running on localhost:8080
```
In the above example, invalid option syntax is being used. However, ConsoleKit simply ignores it.

After this update, invalid syntax will result in an error:

```sh
$ vapor run serve --port=1337
Error: Input not recognized: --port=1337
```