### PR TITLE
Fix double-output of "Error: " label for command errors

### DIFF
--- a/Sources/ConsoleKit/Command/CommandError.swift
+++ b/Sources/ConsoleKit/Command/CommandError.swift
@@ -28,10 +28,10 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
     public var description: String {
         switch self {
         case .missingCommand:
-            return "Error: Missing command"
+            return "Missing command"
         case let .unknownCommand(command, available: available):
             guard !available.isEmpty else {
-                return "Error: Executable doesn't take a command"
+                return "Executable doesn't take a command"
             }
             
             let suggestions: [(String, Int)] = available
@@ -40,22 +40,22 @@ public enum CommandError: Error, Equatable, CustomStringConvertible {
                 .filter(distanceLessThan(3))
             
             guard !suggestions.isEmpty else {
-                return "Error: Unknown command `\(command)`"
+                return "Unknown command `\(command)`"
             }
             
             return """
-            Error: Unknown command `\(command)`
+            Unknown command `\(command)`
             
             Did you mean this?
             
             \(suggestions.map { "\t\($0.0)" }.joined(separator: "\n"))
             """
         case let .missingRequiredArgument(argument):
-            return "Error: Missing required argument: \(argument)"
+            return "Missing required argument: \(argument)"
         case let .invalidArgumentType(argument, type: type):
-            return "Error: Could not convert argument for `\(argument)` to \(type)"
+            return "Could not convert argument for `\(argument)` to \(type)"
         case let .invalidOptionType(option, type: type):
-            return "Error: Could not convert option for `\(option)` to \(type)"
+            return "Could not convert option for `\(option)` to \(type)"
         }
     }
 }

--- a/Tests/ConsoleKitTests/CommandErrorTests.swift
+++ b/Tests/ConsoleKitTests/CommandErrorTests.swift
@@ -11,7 +11,7 @@ class CommandErrorTests: XCTestCase {
                 return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
             XCTAssertEqual(commandError, .missingCommand, "Expected `.missingCommand` error, got \(String(reflecting: error)).")
-            XCTAssertEqual(commandError.description, "Error: Missing command")
+            XCTAssertEqual(commandError.description, "Missing command")
         }
     }
     
@@ -25,7 +25,7 @@ class CommandErrorTests: XCTestCase {
             }
             XCTAssertEqual(commandError, .unknownCommand("sup", available: ["sub", "test"]), "Expected `.unknownCommand` error, got \(String(reflecting: error)).")
             XCTAssertEqual(commandError.description, """
-            Error: Unknown command `sup`
+            Unknown command `sup`
 
             Did you mean this?
 
@@ -44,7 +44,7 @@ class CommandErrorTests: XCTestCase {
             }
             XCTAssertEqual(commandError, .unknownCommand("desoxyribonucleic-acid", available: ["sub", "test"]), "Expected `.unknownCommand` error, got \(String(reflecting: error)).")
             XCTAssertEqual(commandError.description, """
-            Error: Unknown command `desoxyribonucleic-acid`
+            Unknown command `desoxyribonucleic-acid`
             """)
         }
     }
@@ -63,7 +63,7 @@ class CommandErrorTests: XCTestCase {
                 return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
             XCTAssertEqual(commandError, .missingRequiredArgument("number"), "Expected `.missingRequiredArgument` error, got \(String(reflecting: error)).")
-            XCTAssertEqual(commandError.description, "Error: Missing required argument: number")
+            XCTAssertEqual(commandError.description, "Missing required argument: number")
         }
     }
     
@@ -81,7 +81,7 @@ class CommandErrorTests: XCTestCase {
                 return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
             XCTAssertEqual(commandError, .invalidArgumentType("number", type: Int.self), "Expected `.invalidArgumentType` error, got \(String(reflecting: error)).")
-            XCTAssertEqual(commandError.description, "Error: Could not convert argument for `number` to Int")
+            XCTAssertEqual(commandError.description, "Could not convert argument for `number` to Int")
         }
     }
     
@@ -109,7 +109,7 @@ class CommandErrorTests: XCTestCase {
                 return XCTFail("Expected `CommandError` error, got \(type(of: error)).")
             }
             XCTAssertEqual(commandError, .invalidOptionType("bar", type: Int.self), "Expected `.invalidOptionType` error, got \(String(reflecting: error)).")
-            XCTAssertEqual(commandError.description, "Error: Could not convert option for `bar` to Int")
+            XCTAssertEqual(commandError.description, "Could not convert option for `bar` to Int")
         }
     }
     


### PR DESCRIPTION
Because `CommandError.description` includes the "Error: " label in the returned text, practically all formatted error output (especially such as found in vapor/toolbox) ends up printing `Error: Error: ...` for command errors. Since this table is redundant in the `description` of an `Error` anyway, we just remove it. The `description` of an `Error` is human-readable and therefore not parseable, and is thus not considered API, so this is considered a `semver-patch` change.