### PR TITLE
Log metadata at all log levels.

### DIFF
--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -13,8 +13,6 @@ public struct ConsoleLogger: LogHandler {
     /// The conosle that the messages will get logged to.
     public let console: Console
 
-    private let sourcePathDelimiter: Substring
-    
     /// Creates a new `ConsoleLogger` instance.
     ///
     /// - Parameters:
@@ -22,20 +20,11 @@ public struct ConsoleLogger: LogHandler {
     ///   - console: The console to log the messages to.
     ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
     ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    ///   - sourcePathDelimiter: The path component upto which source file paths will be truncated.
-    ///     For example, given a value of `Sources` and a source file path of `/app/Sources/Run/main.swift`, the output
-    ///     will be `Run/main.swift`. Defaults to `Sources`.
-    public init(
-        label: String,
-        console: Console,
-        level: Logger.Level = .debug,
-        metadata: Logger.Metadata = [:],
-        sourcePathDelimiter: String = "Sources") {
+    public init(label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
         self.label = label
         self.metadata = metadata
         self.logLevel = level
         self.console = console
-        self.sourcePathDelimiter = Substring(sourcePathDelimiter)
     }
     
     /// See `LogHandler[metadataKey:]`.
@@ -92,8 +81,9 @@ public struct ConsoleLogger: LogHandler {
     ///     "Run/main.swift"
     ///
     private func conciseSourcePath(_ path: String) -> String {
+        let separator: Substring = path.contains("Sources") ? "Sources" : "Tests"
         return path.split(separator: "/")
-            .split(separator: self.sourcePathDelimiter)
+            .split(separator: separator)
             .last?
             .joined(separator: "/") ?? path
     }
@@ -118,21 +108,9 @@ extension LoggingSystem {
     ///   - console: The console the logger will log the messages to.
     ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
     ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    ///   - sourcePathDelimiter: The path component upto which source file paths will be truncated.
-    ///     For example, given a value of `Sources` and a source file path of `/app/Sources/Run/main.swift`, the output
-    ///     will be `Run/main.swift`. Defaults to `Sources`.
-    public static func bootstrap(
-        console: Console,
-        level: Logger.Level = .info,
-        metadata: Logger.Metadata = [:],
-        sourcePathDelimiter: String = "Sources") {
+    public static func bootstrap(console: Console, level: Logger.Level = .info, metadata: Logger.Metadata = [:]) {
         self.bootstrap { label in
-            return ConsoleLogger(
-                label: label,
-                console: console,
-                level: level,
-                metadata: metadata,
-                sourcePathDelimiter: sourcePathDelimiter)
+            return ConsoleLogger(label: label, console: console, level: level, metadata: metadata)
         }
     }
 }

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -66,9 +66,11 @@ public struct ConsoleLogger: LogHandler {
         
         // only log metadata if we are info or lower
         if self.logLevel <= .info {
-            if !self.metadata.isEmpty {
+            let allMetadata = (metadata ?? [:]).merging(self.metadata) { (a, _) in a }
+
+            if !allMetadata.isEmpty {
                 // only log metadata if not empty
-                text += " " + self.metadata.descriptionWithoutQuotes.consoleText()
+                text += " " + allMetadata.sortedDescriptionWithoutQuotes.consoleText()
             }
         }
 
@@ -97,16 +99,12 @@ public struct ConsoleLogger: LogHandler {
 }
 
 private extension Logger.Metadata {
-    struct StringWithoutQuotes: CustomStringConvertible, Hashable {
-        let description: String
-    }
-
-    var descriptionWithoutQuotes: String {
-        var info: [StringWithoutQuotes: StringWithoutQuotes] = [:]
-        for (key, value) in self {
-            info[.init(description: key.description)] = .init(description: value.description)
-        }
-        return info.description
+    var sortedDescriptionWithoutQuotes: String {
+        let contents = Array(self)
+            .sorted(by: { $0.0 < $1.0 })
+            .map { "\($0.description): \($1)" }
+            .joined(separator: ", ")
+        return "[\(contents)]"
     }
 }
 

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -53,15 +53,12 @@ public struct ConsoleLogger: LogHandler {
         text += "[ \(level.name) ]".consoleText(level.style)
             + " "
             + message.description.consoleText()
-        
-        // only log metadata if we are info or lower
-        if self.logLevel <= .info {
-            let allMetadata = (metadata ?? [:]).merging(self.metadata) { (a, _) in a }
 
-            if !allMetadata.isEmpty {
-                // only log metadata if not empty
-                text += " " + allMetadata.sortedDescriptionWithoutQuotes.consoleText()
-            }
+        let allMetadata = (metadata ?? [:]).merging(self.metadata) { (a, _) in a }
+
+        if !allMetadata.isEmpty {
+            // only log metadata if not empty
+            text += " " + allMetadata.sortedDescriptionWithoutQuotes.consoleText()
         }
 
         // log file info if we are debug or lower

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -25,11 +25,12 @@ public struct ConsoleLogger: LogHandler {
     ///   - sourcePathDelimiter: The path component upto which source file paths will be truncated.
     ///     For example, given a value of `Sources` and a source file path of `/app/Sources/Run/main.swift`, the output
     ///     will be `Run/main.swift`. Defaults to `Sources`.
-    public init(label: String,
-                console: Console,
-                level: Logger.Level = .debug,
-                metadata: Logger.Metadata = [:],
-                sourcePathDelimiter: String = "Sources") {
+    public init(
+        label: String,
+        console: Console,
+        level: Logger.Level = .debug,
+        metadata: Logger.Metadata = [:],
+        sourcePathDelimiter: String = "Sources") {
         self.label = label
         self.metadata = metadata
         self.logLevel = level
@@ -120,16 +121,18 @@ extension LoggingSystem {
     ///   - sourcePathDelimiter: The path component upto which source file paths will be truncated.
     ///     For example, given a value of `Sources` and a source file path of `/app/Sources/Run/main.swift`, the output
     ///     will be `Run/main.swift`. Defaults to `Sources`.
-    public static func bootstrap(console: Console,
-                                 level: Logger.Level = .info,
-                                 metadata: Logger.Metadata = [:],
-                                 sourcePathDelimiter: String = "Sources") {
+    public static func bootstrap(
+        console: Console,
+        level: Logger.Level = .info,
+        metadata: Logger.Metadata = [:],
+        sourcePathDelimiter: String = "Sources") {
         self.bootstrap { label in
-            return ConsoleLogger(label: label,
-                                 console: console,
-                                 level: level,
-                                 metadata: metadata,
-                                 sourcePathDelimiter: sourcePathDelimiter)
+            return ConsoleLogger(
+                label: label,
+                console: console,
+                level: level,
+                metadata: metadata,
+                sourcePathDelimiter: sourcePathDelimiter)
         }
     }
 }

--- a/Tests/ConsoleKitTests/LoggingTests.swift
+++ b/Tests/ConsoleKitTests/LoggingTests.swift
@@ -76,6 +76,6 @@ final class ConsoleLoggerTests: XCTestCase {
     }
 }
 
-private func XCTAssertLog(_ console: TestConsole, _ level: Logger.Level, _ message: String, file: StaticString = #filePath, line: UInt = #line) {
-    XCTAssertEqual(console.testOutputQueue.first, "[ \(level.name) ] \(message)\n", file: file, line: line)
+private func XCTAssertLog(_ console: TestConsole, _ level: Logger.Level, _ message: String, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(console.testOutputQueue.first, "[ \(level.name) ] \(message)\n", file: (file), line: line)
 }

--- a/Tests/ConsoleKitTests/LoggingTests.swift
+++ b/Tests/ConsoleKitTests/LoggingTests.swift
@@ -52,11 +52,17 @@ final class ConsoleLoggerTests: XCTestCase {
     func testMetadata() {
         let console = TestConsole()
         let logger = Logger(label: "codes.vapor.console") { label in
-            ConsoleLogger(label: label, console: console, level: .info, metadata: ["meta": "test"])
+            ConsoleLogger(label: label, console: console, level: .info, metadata: ["meta1": "test1"])
         }
 
         logger.info("info")
-        XCTAssertLog(console, .info, "info [meta: test]")
+        XCTAssertLog(console, .info, "info [meta1: test1]")
+
+        logger.info("info", metadata: ["meta2": "test2"])
+        XCTAssertLog(console, .info, "info [meta1: test1, meta2: test2]")
+
+        logger.info("info", metadata: ["meta1": "overridden"])
+        XCTAssertLog(console, .info, "info [meta1: overridden]")
     }
 
     func testSourceLocation() {
@@ -66,7 +72,7 @@ final class ConsoleLoggerTests: XCTestCase {
         }
 
         logger.debug("debug")
-        XCTAssertLog(console, .debug, "debug (LoggingTests.swift:68)")
+        XCTAssertLog(console, .debug, "debug (LoggingTests.swift:74)")
     }
 }
 

--- a/Tests/ConsoleKitTests/LoggingTests.swift
+++ b/Tests/ConsoleKitTests/LoggingTests.swift
@@ -68,11 +68,11 @@ final class ConsoleLoggerTests: XCTestCase {
     func testSourceLocation() {
         let console = TestConsole()
         let logger = Logger(label: "codes.vapor.console") { label in
-            ConsoleLogger(label: label, console: console, level: .debug, sourcePathDelimiter: "ConsoleKitTests")
+            ConsoleLogger(label: label, console: console, level: .debug)
         }
 
         logger.debug("debug")
-        XCTAssertLog(console, .debug, "debug (LoggingTests.swift:74)")
+        XCTAssertLog(console, .debug, "debug (ConsoleKitTests/LoggingTests.swift:74)")
     }
 }
 


### PR DESCRIPTION
Log metadata at all log levels. Previously, metadata was only logged at the `debug` log level.  (#149)