### PR TITLE
Modernization of secure input using Console - take two

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,16 @@ jobs:
       - uses: actions/checkout@v2
       - run: swift test --enable-test-discovery --sanitize=thread
   macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        xcodever:
+          - latest
+          - latest-stable
     runs-on: macos-latest
     steps:
       - uses: maxim-lobanov/setup-xcode@v1.1
-        with: { 'xcode-version': 'latest' }
+        with: { 'xcode-version': '${{ matrix.xcodever }}' }
       - uses: actions/checkout@v2
       - run: swift test --enable-test-discovery --sanitize=thread
   integration-linux:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,40 +2,43 @@ name: test
 on:
 - pull_request
 jobs:
-  console-kit_linux:
-    runs-on: ubuntu-latest
+  linux:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - swift:5.2-xenial
-          - swift:5.2-bionic
-          - swiftlang/swift:nightly-5.2-xenial
-          - swiftlang/swift:nightly-5.2-bionic
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
-          - swiftlang/swift:nightly-master-xenial
-          - swiftlang/swift:nightly-master-bionic
-          - swiftlang/swift:nightly-master-focal
-        include:
-          - { image: 'swiftlang/swift:nightly-master-centos8', depscmd: 'dnf install -y zlib-devel' }
-          - { image: 'swiftlang/swift:nightly-master-amazonlinux2', depscmd: 'yum install -y zlib-devel' }
-    container: ${{ matrix.image }}
+        swiftver:
+          - swift:5.2
+          - swift:5.3
+          - swiftlang/swift:nightly-5.3
+          - swiftlang/swift:nightly-master
+        swiftos:
+          - xenial
+          - bionic
+          - focal
+          - centos7
+          - centos8
+          - amazonlinux2
+    runs-on: ubuntu-latest
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     steps:
-      - run: ${{ matrix.depscmd }}
+      - name: SPM is incompatible with CentOS 7
+        if: ${{ matrix.swiftos == 'centos7' }}
+        run: |
+          yum install -y make libcurl-devel
+          git clone https://github.com/git/git -bv2.28.0 --depth 1 && cd git
+          make prefix=/usr -j all install NO_OPENSSL=1 NO_EXPAT=1 NO_TCLTK=1 NO_GETTEXT=1 NO_PERL=1
       - uses: actions/checkout@v2
       - run: swift test --enable-test-discovery --sanitize=thread
-  console-kit_macos:
+  macos:
     runs-on: macos-latest
     steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+      - uses: maxim-lobanov/setup-xcode@v1.1
         with: { 'xcode-version': 'latest' }
       - uses: actions/checkout@v2
       - run: swift test --enable-test-discovery --sanitize=thread
-  vapor-integration_linux:
+  integration-linux:
     runs-on: ubuntu-latest
-    container: swift:5.2-bionic
+    container: swift:5.3-focal
     steps:
       - uses: actions/checkout@v2
         with: { path: console-kit }
@@ -43,15 +46,14 @@ jobs:
         with: { repository: 'vapor/vapor', path: vapor }
       - run: swift package --package-path vapor edit console-kit --path console-kit
       - run: swift test --package-path vapor --enable-test-discovery --sanitize=thread
-  vapor-integration_macos:
+  integration-macos:
     runs-on: macos-latest
     steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+      - uses: maxim-lobanov/setup-xcode@v1.1
         with: { 'xcode-version': 'latest' }
       - uses: actions/checkout@v2
-        with: { path: 'console-kit' }
+        with: { path: console-kit }
       - uses: actions/checkout@v2
-        with: { repository: 'vapor/vapor', path: 'vapor' }
+        with: { repository: 'vapor/vapor', path: vapor }
       - run: swift package --package-path vapor edit console-kit --path console-kit
       - run: swift test --package-path vapor --enable-test-discovery --sanitize=thread

--- a/Sources/ConsoleKit/Terminal/Terminal.swift
+++ b/Sources/ConsoleKit/Terminal/Terminal.swift
@@ -1,7 +1,9 @@
 #if os(Linux)
 import Glibc
-#else
+#elseif os(macOS)
 import Darwin.C
+#elseif os(Windows)
+import MSVCRT
 #endif
 import Foundation
 
@@ -43,12 +45,43 @@ public final class Terminal: Console {
     public func input(isSecure: Bool) -> String {
         didOutputLines(count: 1)
         if isSecure {
-            // http://stackoverflow.com/a/30878869/2611971
-            let entry: UnsafeMutablePointer<Int8> = getpass("")
-            let pointer: UnsafePointer<CChar> = .init(entry)
-            guard var pass = String(validatingUTF8: pointer) else {
-                return ""
+#if os(macOS) || os(Linux)
+            var pass: String
+            func plat_readpassphrase(into buf: UnsafeMutableBufferPointer<Int8>) -> Int {
+                #if os(macOS)
+                let rpp = readpassphrase
+                #elseif os(Linux)
+                let rpp = linux_readpassphrase, RPP_REQUIRE_TTY = 0 as Int32
+                #endif
+
+                while rpp("", buf.baseAddress!, buf.count, RPP_REQUIRE_TTY) == nil {
+                    guard errno == EINTR else { return 0 }
+                }
+                return strlen(buf.baseAddress!)
             }
+            if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+#if swift(>=5.3)
+                pass = String(unsafeUninitializedCapacity: 1024) { $0.withMemoryRebound(to: Int8.self) { plat_readpassphrase(into: $0) } }
+#else
+                fatalError()
+#endif
+            } else {
+                let buffer = Array<UTF8.CodeUnit>(unsafeUninitializedCapacity: 1024) { buf, count in
+                    buf.withMemoryRebound(to: Int8.self) { count = plat_readpassphrase(into: $0) }
+                }
+                pass = String.init(decoding: buffer, as: UTF8.self)
+            }
+#elseif os(Windows)
+            var pass = ""
+            while pass.count < 32768 { // arbitrary upper bound for sanity
+                let c = _getch()
+                if c == 0x0d || c == 0x0a {
+                    break
+                } else if isprint(c) {
+                    pass.append(Character(Unicode.Scalar(c)))
+                }
+            }
+#endif
             if pass.hasSuffix("\n") {
                 pass = String(pass.dropLast())
             }

--- a/Sources/ConsoleKit/Terminal/readpassphrase_linux.swift
+++ b/Sources/ConsoleKit/Terminal/readpassphrase_linux.swift
@@ -1,0 +1,140 @@
+// This implementation is only used on Linux, but we enable building it on macOS in debug for testing purposes.
+#if os(Linux) || (os(macOS) && DEBUG)
+#if os(Linux)
+import Glibc
+#elseif os(macOS)
+import Darwin
+#endif
+import Dispatch
+
+/// This implementation of `readpassphrase()`, used only on Linux where it's extremely difficult to get at the `libbsd`
+/// API even when it is definitely present, is even less tolerant of being called on multiple threads at once than the
+/// original. It was already never sensible to do so in any case; the interface doesn't have enough smarts to be able to
+/// interact with arbitrary terminals - it can only deal with `/dev/tty`. `libbsd`'s version will just fall on the floor
+/// and make an interesting mess of the process signal handlers if one tries it. This version does it one better: It's a
+/// fatal error to call it off the main thread. This enables us to have the signal recovery handler write to somewhere
+/// it can find without risking intervention from the Swift runtime at async-signal time.
+internal func linux_readpassphrase(_ prompt: UnsafePointer<Int8>, _ buf: UnsafeMutablePointer<Int8>, _ bufsiz: Int, _ flags: Int32) -> UnsafeMutablePointer<Int8>? {
+    dispatchPrecondition(condition: .onQueue(.main))
+    
+    precondition((flags & 0x20/* RPP_STDIN */) == 0, "RPP_STDIN is not supported by this implementation")
+    precondition((flags & 0x04/* RPP_FORCELOWER */) == 0, "RPP_FORCELOWER is not supported by this implementation")
+    precondition((flags & 0x08/* RPP_FORCEUPPER */) == 0, "RPP_FORCEUPPER is not supported by this implementation")
+    precondition((flags & 0x10/* RPP_SEVENBIT */) == 0, "RPP_SEVENBIT is not supported by this implementation")
+    
+    #if os(Linux)
+    let TCSASOFT = 0 as Int32
+    #endif
+    
+    // Open /dev/tty
+    let fd = open("/dev/tty", O_RDWR)
+    guard fd >= 0 else { return nil }
+    defer { close(fd) }
+    
+    // Disable echo
+    var oterm = termios(), term = termios()
+    guard tcgetattr(fd, &oterm) == 0 else { return nil }
+    term = oterm
+    if (flags & 0x1/* RPP_ECHO_ON */) == 0 {
+        term.c_lflag &= tcflag_t(bitPattern: numericCast(~(ECHO | ECHONL)))
+    }
+    _ = tcsetattr(fd, TCSAFLUSH | TCSASOFT, &term) // libbsd ignores it if this calls fails, should we be doing the same?
+    
+    // Reset the signal counts and install a recovery handler onto a whole buncha signals
+    linux_readpassphrase_signos.reset()
+    var sigrecovery = sigaction(), sigsave = sigaction(), sigsaves: [Int32: sigaction] = [
+        SIGALRM: .init(),   SIGHUP: .init(),    SIGINT: .init(),    SIGPIPE: .init(),   SIGQUIT: .init(),
+        SIGTERM: .init(),   SIGTSTP: .init(),   SIGTTIN: .init(),   SIGTTOU: .init(),
+    ]
+    sigemptyset(&sigrecovery.sa_mask)
+    sigrecovery.sa_flags = 0
+    #if os(macOS)
+    sigrecovery.__sigaction_u = .init(__sa_handler: { linux_readpassphrase_signos[$0] += 1 })
+    #elseif os(Linux)
+    sigrecovery.__sigaction_handler = .init(sa_handler: { linux_readpassphrase_signos[$0] += 1 })
+    #endif
+    for (sig, _) in sigsaves { sigaction(sig, &sigrecovery, &sigsave); sigsaves[sig] = sigsave }
+    
+    // Loop over a read() call, character by character. At the end, null-terminate. If echo is disabled, write a newline.
+    var i = 0, nr = 1, save_errno = 0 as Int32
+    var c: Int8 = 0
+    while i < bufsiz - 1 && nr == 1 && c != 0x0a && c != 0x0d {
+        nr = read(fd, &c, 1)
+        if nr == 1 { buf[i] = c; i += 1 }
+    }
+    buf[i] = 0
+    save_errno = errno // save off errno for later restoration after the state restoration stuff below
+    if (term.c_lflag & tcflag_t(bitPattern: numericCast(ECHO))) == 0 { write(fd, "\n", 1) }
+    
+    // Restore original terminal config
+    if memcmp(&term, &oterm, MemoryLayout<termios>.size) != 0 {
+        // I don't understand what this sequence accomplishes with respect to ignoring SIGTTOU.
+        let save_sigttou = linux_readpassphrase_signos[SIGTTOU]
+        while tcsetattr(fd, TCSAFLUSH | TCSASOFT, &oterm) == -1 && errno == EINTR && linux_readpassphrase_signos[SIGTTOU] == 0 {
+            continue
+        }
+        linux_readpassphrase_signos[SIGTTOU] = save_sigttou
+    }
+    
+    // Restore signal handlers
+    for (sig, var sa) in sigsaves { sigaction(sig, &sa, nil) }
+    
+    // libbsd closes the TTY fd here. Since we deferred the fd closure, we just hope the difference doesn't cause problems.
+    
+    // Re-raise any signals we temporarily ignored, now that the old signal handlers are back in place.
+    for i in 0..<NSIG where linux_readpassphrase_signos[i] != 0 {
+        kill(getpid(), i)
+        // libbsd restarts the entire readpassphrase() execution if the signal was SIGTSTP, SIGTTIN, or SIGTTOU. Using goto.
+        // It makes sense functionally, but it's more trouble than it's worth for now.
+    }
+    
+    // Return nil for a `read(2)` error.
+    if save_errno != 0 {
+        errno = save_errno
+    }
+    return nr == -1 ? nil : buf
+}
+
+/// Used for signal recovery by `linux_readpassphrase()`. This is `static volatile` storage in the original.
+/// We must avoid any accesses into the Swift runtime in the signal handler, so this is manually allocated
+/// storage rather than a simple array. It is never deallocated and will be considered a leak by memory
+/// analysis tools.
+fileprivate var linux_readpassphrase_signos: VeryUnsafeMutableSigAtomicBufferPointer = .init(capacity: NSIG)
+
+/// A version of `UnsafeMutableBufferPointer` which avoids any references to the Swift runtime, including conformance to
+/// `Collection` or `Sequence`, etc. Guaranteed to only ever allocate once. Provides a (typically global) "array" of
+/// `sig_atomic_t` values suitable for use by a signal handler to communicate state changes to other code. Promises to
+/// obey all async-signal-safe rules (such as reentrancy tolerance and avoidance of non-async-signal-safe library
+/// functions) except during `init`. Not suitable for much else besides use by signal handlers. This is a deliberately
+/// "badly" designed structure according to established Swift idioms; it eschews protocol conformances, abstractions
+/// such as `Index` and `Element` typealiases, and the use of any runtime facilities _ON PURPOSE_. Do _NOT_ add such
+/// things to this structure thinking that you're improving it. You're not. I promise. Most especially, don't try to
+/// extend it to do things like "initialize", "bind", "move", "assign", etc. operations on memory correctly. It's wrong
+/// deliberately. Swift has no other model for doing this kind of thing yet.
+///
+/// If you think you want to use this for something, you're wrong.
+fileprivate struct VeryUnsafeMutableSigAtomicBufferPointer {
+    let capacity: Int
+    let baseAddress: UnsafeMutablePointer<sig_atomic_t>
+    
+    init<I: FixedWidthInteger & BinaryInteger>(capacity: I) {
+        self.capacity = Int(capacity)
+        self.baseAddress = .allocate(capacity: self.capacity)
+    }
+    
+    subscript(_ index: Int) -> sig_atomic_t {
+        get { self.baseAddress.advanced(by: index).pointee }
+        set { self.baseAddress.advanced(by: index).pointee = newValue }
+    }
+
+    subscript(_ index: Int32) -> sig_atomic_t {
+        get { self[Int(index)] }
+        set { self[Int(index)] = newValue }
+    }
+    
+    func reset() {
+        self.baseAddress.assign(repeating: 0, count: self.capacity)
+    }
+}
+#endif
+

--- a/Sources/ConsoleKitExample/DemoCommand.swift
+++ b/Sources/ConsoleKitExample/DemoCommand.swift
@@ -52,5 +52,9 @@ final class DemoCommand: Command {
             context.console.wait(seconds: 2)
             loadingBar.succeed()
         }
+        
+        context.console.output("Now for secure input: ", newLine: false)
+        let input = context.console.input(isSecure: true)
+        context.console.output("Your secure input was: \(input)")
     }
 }


### PR DESCRIPTION
This is a rehash of #153 with improved compatibility and a better testing matrix.

`getpass()` is very, very old, and deprecated everywhere it exists. This PR switches to `readpassphrase()` on macOS, provides a (incomplete but sufficient) re-implementation of `readpassphrase()` based on that of `libbsd` for Linux, and adds an implementation for Windows using the `conio` interface.