### PR TITLE
Fix warnings from Swift 5.4 compiler

### DIFF
--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -46,7 +46,7 @@ enum InputValue<T> {
     case uninitialized
 }
 
-internal protocol AnySignatureValue: class {
+internal protocol AnySignatureValue: AnyObject {
     var help: String { get }
     var name: String { get }
     var initialized: Bool { get }

--- a/Sources/ConsoleKit/Console.swift
+++ b/Sources/ConsoleKit/Console.swift
@@ -34,7 +34,7 @@
 ///
 /// Get the `Console`'s current size using the `size` property.
 ///
-public protocol Console: class {
+public protocol Console: AnyObject {
     /// The size of the `Console` window. Used for calculating lines printed and centering text.
     var size: (width: Int, height: Int) { get }
 


### PR DESCRIPTION
Fixes the following warnings now produced by the Swift 5.4 compiler:

```
warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol Console: class {
                         ^~~~~
                         AnyObject
```