### PR TITLE
Change run() to run() async

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,12 @@ let package = Package(
     targets: [
         .target(name: "ConsoleKit", dependencies: [
             .product(name: "Logging", package: "swift-log"),
+        ],
+        swiftSettings: [
+            .unsafeFlags([
+                "-Xfrontend", "-enable-experimental-concurrency",
+                "-Xfrontend", "-disable-availability-checking",
+            ])
         ]),
         .testTarget(name: "ConsoleKitTests", dependencies: [
             .target(name: "ConsoleKit"),

--- a/Sources/ConsoleKit/Command/AnyCommand.swift
+++ b/Sources/ConsoleKit/Command/AnyCommand.swift
@@ -4,7 +4,7 @@ public protocol AnyCommand {
     var help: String { get }
     
     /// Runs the command against the supplied input.
-    func run(using context: inout CommandContext) throws
+    func run(using context: inout CommandContext) async throws
     func outputAutoComplete(using context: inout CommandContext) throws
     func outputHelp(using context: inout CommandContext) throws
 

--- a/Sources/ConsoleKit/Command/CommandGroup.swift
+++ b/Sources/ConsoleKit/Command/CommandGroup.swift
@@ -25,11 +25,11 @@ extension CommandGroup {
 }
 
 extension CommandGroup {
-    public func run(using context: inout CommandContext) throws {
+    public func run(using context: inout CommandContext) async throws {
         if let command = try self.commmand(using: &context) {
-            try command.run(using: &context)
+            try await command.run(using: &context)
         } else if let `default` = self.defaultCommand {
-            return try `default`.run(using: &context)
+            return try await `default`.run(using: &context)
         } else {
             try self.outputHelp(using: &context)
             throw CommandError.missingCommand

--- a/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
@@ -37,7 +37,7 @@ struct GenerateAutocompleteCommand: Command {
         var quiet: Bool
     }
 
-    func run(using context: CommandContext, signature: Signature) throws {
+    func run(using context: CommandContext, signature: Signature) async throws {
 
         guard let rootCommand = self.rootCommand else { fatalError("`rootCommand` was not initialized") }
         guard let shell = signature.shell ?? self.environmentShell() else {


### PR DESCRIPTION
Clumsy start at an attempt to fix https://github.com/vapor/vapor/issues/2635

According to what I've read, an `f() async` protocol requirement can be implemented by `f()` - meaning existing protocol conformances should continue to work.

The current code does compile but since I used `DispatchGroup`, errors are not passed through.

The alternative would be to use

```swift
import _NIOConcurrency

let promise = ...eventLoop.makePromise(of: Void.self)
promise.completeWithAsync {
    try await self.run(command, with: CommandContext(console: self, input: input))
}
try promise.futureResult.wait()
```

However, swift-nio isn't currently a package dependency. Maybe it's possible to extract just `promise.completeWithAsync` from it but it wasn't immediately obvious how that could be done.

This might be a complete dead end or perhaps it's a useful start :)