### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,49 +2,14 @@ name: test
 on:
 - pull_request
 jobs:
-  linux:
-    strategy:
-      fail-fast: false
-      matrix:
-        swiftver:
-          - swift:5.2
-          - swift:5.3
-          - swiftlang/swift:nightly-5.3
-          - swiftlang/swift:nightly-master
-        swiftos:
-          - xenial
-          - bionic
-          - focal
-          - centos7
-          - centos8
-          - amazonlinux2
-    runs-on: ubuntu-latest
-    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
-    steps:
-      - name: SPM is incompatible with CentOS 7
-        if: ${{ matrix.swiftos == 'centos7' }}
-        run: |
-          yum install -y make libcurl-devel
-          git clone https://github.com/git/git -bv2.28.0 --depth 1 && cd git
-          make prefix=/usr -j all install NO_OPENSSL=1 NO_EXPAT=1 NO_TCLTK=1 NO_GETTEXT=1 NO_PERL=1
-      - uses: actions/checkout@v2
-      - run: swift test --enable-test-discovery --sanitize=thread
-  macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        xcodever:
-          - latest
-          - latest-stable
-    runs-on: macos-latest
-    steps:
-      - uses: maxim-lobanov/setup-xcode@v1.1
-        with: { 'xcode-version': '${{ matrix.xcodever }}' }
-      - uses: actions/checkout@v2
-      - run: swift test --enable-test-discovery --sanitize=thread
+  unit-tests:
+     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+     with:
+       with_coverage: false
+       with_tsan: true
   integration-linux:
     runs-on: ubuntu-latest
-    container: swift:5.3-focal
+    container: swift:5.6-focal
     steps:
       - uses: actions/checkout@v2
         with: { path: console-kit }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)