### PR TITLE
Add experimental support for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "console-kit",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_15),
+       .iOS(.v13)
     ],
     products: [
         .library(name: "ConsoleKit", targets: ["ConsoleKit"]),

--- a/Sources/ConsoleKit/Command/Async/AnyAsyncCommand.swift
+++ b/Sources/ConsoleKit/Command/Async/AnyAsyncCommand.swift
@@ -1,4 +1,4 @@
-#if swift(>=5.5)
+#if swift(>=5.5)  && canImport(_Concurrency)
 /// A type-erased `Command`.
 public protocol AnyAsyncCommand {
     /// Text that will be displayed when `--help` is passed.
@@ -12,9 +12,7 @@ public protocol AnyAsyncCommand {
     /// Renders the shell completion script functions for the command and any descendent subcommands.
     func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String
 }
-#endif
 
-#if swift(>=5.5)
 extension AnyAsyncCommand {
     public func outputAutoComplete(using context: inout CommandContext) {
         // do nothing

--- a/Sources/ConsoleKit/Command/Async/AsyncCommand.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommand.swift
@@ -78,7 +78,7 @@
 ///                     U  ||----w |
 ///                        ||     ||
 ///
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 public protocol AsyncCommand: AnyAsyncCommand {
     associatedtype Signature: CommandSignature
     func run(using context: CommandContext, signature: Signature) async throws

--- a/Sources/ConsoleKit/Command/Async/AsyncCommandGroup.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommandGroup.swift
@@ -13,7 +13,7 @@
 ///     try await console.run(group, with: context)
 ///
 /// You can create your own `AsyncCommandGroup` if you want to support custom `CommandOptions`.
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 public protocol AsyncCommandGroup: AnyAsyncCommand {
     var commands: [String: AnyAsyncCommand] { get }
     var defaultCommand: AnyAsyncCommand? { get }

--- a/Sources/ConsoleKit/Command/Async/AsyncCommands.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommands.swift
@@ -1,5 +1,5 @@
 /// Represents a top-level group of configured commands. This is usually created by calling `resolve(for:)` on `AsyncCommands`.
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 public struct AsyncCommands {
     /// Top-level available commands, stored by unique name.
     public var commands: [String: AnyAsyncCommand]

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -26,7 +26,7 @@ extension AnyCommand {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 extension AnyAsyncCommand {
 
     /// Returns the complete contents of a completion script for the given `shell`
@@ -55,7 +55,7 @@ extension Command {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 extension AsyncCommand {
 
     // See `AnyAsyncCommand`.
@@ -90,7 +90,7 @@ extension CommandGroup {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 extension AsyncCommandGroup {
 
     // See `AnyAsyncCommand`.
@@ -289,7 +289,7 @@ extension AnyCommand {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 extension AnyAsyncCommand {
 
     /// Returns the contents of a bash completion file for `self` and, recursively,

--- a/Sources/ConsoleKit/Command/Console+Run.swift
+++ b/Sources/ConsoleKit/Command/Console+Run.swift
@@ -45,7 +45,7 @@ extension Console {
         }
     }
     
-    #if swift(>=5.5)
+    #if swift(>=5.5) && canImport(_Concurrency)
     /// Runs an `AnyAsyncCommand` (`AsyncCommandGroup` or `AsyncCommand`) of commands on this `Console` using the supplied `CommandInput`.
     ///
     ///     try await console.run(group, input: commandInput)

--- a/Sources/ConsoleKit/Utilities/GenerateAsyncAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAsyncAutocompleteCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 struct GenerateAsyncAutocompleteCommand: AsyncCommand {
     var help: String { "Generate shell completion scripts for the executable" }
 

--- a/Sources/ConsoleKitAsyncExample/DemoCommand.swift
+++ b/Sources/ConsoleKitAsyncExample/DemoCommand.swift
@@ -1,6 +1,6 @@
 import ConsoleKit
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 final class DemoCommand: AsyncCommand {
     struct Signature: CommandSignature {
         @Flag(name: "color", short: "c", help: "Enables colorized output")

--- a/Sources/ConsoleKitAsyncExample/entry.swift
+++ b/Sources/ConsoleKitAsyncExample/entry.swift
@@ -1,6 +1,6 @@
 import ConsoleKit
 import Foundation
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 @main
 struct AsyncExample {
     static func main() async throws {

--- a/Tests/AsyncConsoleKitTests/AsyncCommandErrorTests.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncCommandErrorTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 class AsyncCommandErrorTests: XCTestCase {
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
     func testMissingCommand() async throws {
         let console = TestConsole()
         let group = TestGroup()

--- a/Tests/AsyncConsoleKitTests/AsyncCommandTests.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncCommandTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 class AsyncCommandTests: XCTestCase {
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
     func testBaseHelp() async throws {
         let console = TestConsole()
         let group = TestGroup()

--- a/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
@@ -1,7 +1,7 @@
 import ConsoleKit
 import XCTest
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 extension String: Error {}
 
 final class TestGroup: AsyncCommandGroup {


### PR DESCRIPTION
This adds experimental support for iOS and fixes up the concurrency stuff by making sure concurrency is available.

Resolves #172 