### PR TITLE
Fix compilation on older OSes

### DIFF
--- a/Sources/ConsoleKit/Command/Async/AnyAsyncCommand.swift
+++ b/Sources/ConsoleKit/Command/Async/AnyAsyncCommand.swift
@@ -1,5 +1,6 @@
 #if swift(>=5.5)  && canImport(_Concurrency)
 /// A type-erased `Command`.
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AnyAsyncCommand {
     /// Text that will be displayed when `--help` is passed.
     var help: String { get }
@@ -13,6 +14,7 @@ public protocol AnyAsyncCommand {
     func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AnyAsyncCommand {
     public func outputAutoComplete(using context: inout CommandContext) {
         // do nothing

--- a/Sources/ConsoleKit/Command/Async/AsyncCommand.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommand.swift
@@ -79,11 +79,13 @@
 ///                        ||     ||
 ///
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncCommand: AnyAsyncCommand {
     associatedtype Signature: CommandSignature
     func run(using context: CommandContext, signature: Signature) async throws
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncCommand {
     public func run(using context: inout CommandContext) async throws {
         let signature = try Signature(from: &context.input)

--- a/Sources/ConsoleKit/Command/Async/AsyncCommandGroup.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommandGroup.swift
@@ -14,17 +14,20 @@
 ///
 /// You can create your own `AsyncCommandGroup` if you want to support custom `CommandOptions`.
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncCommandGroup: AnyAsyncCommand {
     var commands: [String: AnyAsyncCommand] { get }
     var defaultCommand: AnyAsyncCommand? { get }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncCommandGroup {
     public var defaultCommand: AnyAsyncCommand? {
         return nil
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncCommandGroup {
     public func run(using context: inout CommandContext) async throws {
         if let command = try self.commmand(using: &context) {

--- a/Sources/ConsoleKit/Command/Async/AsyncCommands.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommands.swift
@@ -1,5 +1,6 @@
 /// Represents a top-level group of configured commands. This is usually created by calling `resolve(for:)` on `AsyncCommands`.
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public struct AsyncCommands {
     /// Top-level available commands, stored by unique name.
     public var commands: [String: AnyAsyncCommand]
@@ -85,6 +86,7 @@ public struct AsyncCommands {
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 private struct _AsyncGroup: AsyncCommandGroup {
     var commands: [String: AnyAsyncCommand]
     var defaultCommand: AnyAsyncCommand?

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -27,6 +27,7 @@ extension AnyCommand {
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AnyAsyncCommand {
 
     /// Returns the complete contents of a completion script for the given `shell`
@@ -56,6 +57,7 @@ extension Command {
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncCommand {
 
     // See `AnyAsyncCommand`.
@@ -91,6 +93,7 @@ extension CommandGroup {
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncCommandGroup {
 
     // See `AnyAsyncCommand`.
@@ -290,6 +293,7 @@ extension AnyCommand {
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AnyAsyncCommand {
 
     /// Returns the contents of a bash completion file for `self` and, recursively,

--- a/Sources/ConsoleKit/Command/Console+Run.swift
+++ b/Sources/ConsoleKit/Command/Console+Run.swift
@@ -56,6 +56,7 @@ extension Console {
     /// - parameters:
     ///     - command: `AsyncCommandGroup` or `AsyncCommand` to run.
     ///     - input: `CommandInput` to parse `CommandOption`s and `CommandArgument`s from.
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func run(_ command: AnyAsyncCommand, input: CommandInput) async throws {
         // create new context
         try await self.run(command, with: CommandContext(console: self, input: input))
@@ -68,6 +69,7 @@ extension Console {
     /// - parameters:
     ///     - runnable: `AsyncCommandGroup` or `AsyncCommand` to run.
     ///     - input: `CommandContext` to parse `CommandOption`s and `CommandArgument`s from.
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func run(_ command: AnyAsyncCommand, with context: CommandContext) async throws {
         // make copy of context
         var context = context

--- a/Sources/ConsoleKit/Utilities/GenerateAsyncAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAsyncAutocompleteCommand.swift
@@ -1,5 +1,6 @@
 import Foundation
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 struct GenerateAsyncAutocompleteCommand: AsyncCommand {
     var help: String { "Generate shell completion scripts for the executable" }
 

--- a/Sources/ConsoleKitAsyncExample/DemoCommand.swift
+++ b/Sources/ConsoleKitAsyncExample/DemoCommand.swift
@@ -1,6 +1,7 @@
 import ConsoleKit
 
 #if swift(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class DemoCommand: AsyncCommand {
     struct Signature: CommandSignature {
         @Flag(name: "color", short: "c", help: "Enables colorized output")

--- a/Sources/ConsoleKitAsyncExample/entry.swift
+++ b/Sources/ConsoleKitAsyncExample/entry.swift
@@ -2,6 +2,7 @@ import ConsoleKit
 import Foundation
 #if swift(>=5.5) && canImport(_Concurrency)
 @main
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 struct AsyncExample {
     static func main() async throws {
         let console: Console = Terminal()

--- a/Tests/AsyncConsoleKitTests/AsyncCommandErrorTests.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncCommandErrorTests.swift
@@ -1,6 +1,7 @@
 @testable import ConsoleKit
 import XCTest
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 class AsyncCommandErrorTests: XCTestCase {
 #if swift(>=5.5) && canImport(_Concurrency)
     func testMissingCommand() async throws {

--- a/Tests/AsyncConsoleKitTests/AsyncCommandTests.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncCommandTests.swift
@@ -1,6 +1,7 @@
 @testable import ConsoleKit
 import XCTest
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 class AsyncCommandTests: XCTestCase {
 #if swift(>=5.5) && canImport(_Concurrency)
     func testBaseHelp() async throws {

--- a/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
@@ -4,6 +4,7 @@ import XCTest
 #if swift(>=5.5) && canImport(_Concurrency)
 extension String: Error {}
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class TestGroup: AsyncCommandGroup {
     struct Signature: CommandSignature {
         @Flag(name: "version", help: "Prints the version")
@@ -25,6 +26,7 @@ final class TestGroup: AsyncCommandGroup {
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class SubGroup: AsyncCommandGroup {
     struct Signature: CommandSignature {
         @Flag(name: "version", help: "Prints the version")
@@ -45,6 +47,7 @@ final class SubGroup: AsyncCommandGroup {
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class TestCommand: AsyncCommand {
     struct Signature: CommandSignature {
         @Argument(name: "foo", help: """
@@ -78,6 +81,7 @@ final class TestCommand: AsyncCommand {
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class StrictCommand: AsyncCommand {
     struct Signature: CommandSignature {
         @Argument(name: "number")


### PR DESCRIPTION
Fixes an issue where compilation would fail on older versions of macOS when using Swift 5.5
