### PR TITLE
Add MetadataProvider support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "ConsoleKit", targets: ["ConsoleKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.1"),
     ],
     targets: [
         .target(name: "ConsoleKit", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .testTarget(name: "AsyncConsoleKitTests", dependencies: [
             .target(name: "ConsoleKit"),
         ]),
-        .target(name: "ConsoleKitExample", dependencies: [
+        .executableTarget(name: "ConsoleKitExample", dependencies: [
             .target(name: "ConsoleKit"),
         ]),
         .target(name: "ConsoleKitAsyncExample", dependencies: [

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -7,6 +7,9 @@ public struct ConsoleLogger: LogHandler {
     /// See `LogHandler.metadata`.
     public var metadata: Logger.Metadata
     
+    /// See `LogHandler.metadataProvider`.
+    public var metadataProvider: Logger.MetadataProvider?
+    
     /// See `LogHandler.logLevel`.
     public var logLevel: Logger.Level
     
@@ -25,6 +28,14 @@ public struct ConsoleLogger: LogHandler {
         self.metadata = metadata
         self.logLevel = level
         self.console = console
+    }
+    
+    public init(label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+        self.label = label
+        self.metadata = metadata
+        self.logLevel = level
+        self.console = console
+        self.metadataProvider = metadataProvider
     }
     
     /// See `LogHandler[metadataKey:]`.
@@ -54,7 +65,10 @@ public struct ConsoleLogger: LogHandler {
             + " "
             + message.description.consoleText()
 
-        let allMetadata = (metadata ?? [:]).merging(self.metadata) { (a, _) in a }
+        let providedMetadata = self.metadataProvider?.get()
+        let allMetadata = (providedMetadata ?? [:])
+            .merging(metadata ?? [:], uniquingKeysWith: { (a, _) in a })
+            .merging(self.metadata, uniquingKeysWith: { (a, _) in a })
 
         if !allMetadata.isEmpty {
             // only log metadata if not empty

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -65,10 +65,9 @@ public struct ConsoleLogger: LogHandler {
             + " "
             + message.description.consoleText()
 
-        let providedMetadata = self.metadataProvider?.get()
-        let allMetadata = (providedMetadata ?? [:])
-            .merging(metadata ?? [:], uniquingKeysWith: { (a, _) in a })
+        let allMetadata = (metadata ?? [:])
             .merging(self.metadata, uniquingKeysWith: { (a, _) in a })
+            .merging(self.metadataProvider?.get() ?? [:], uniquingKeysWith: { (a, _) in a })
 
         if !allMetadata.isEmpty {
             // only log metadata if not empty

--- a/Sources/ConsoleKitAsyncExample/entry.swift
+++ b/Sources/ConsoleKitAsyncExample/entry.swift
@@ -7,7 +7,6 @@ struct AsyncExample {
     static func main() async throws {
         let console: Console = Terminal()
         let input = CommandInput(arguments: CommandLine.arguments)
-        var context = CommandContext(console: console, input: input)
 
         var commands = AsyncCommands(enableAutocomplete: true)
         commands.use(DemoCommand(), as: "demo", isDefault: false)


### PR DESCRIPTION
This PR:
* Adds `MetadataProvider` support to `ConsoleLogger`.
* Makes it so the the package requires `swift-log` `1.5.1`+.
* Fixes these warnings:
```
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
```