### PR TITLE
Implement LoggerFragment system for customizing logger output

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
@@ -14,10 +14,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
     ],
     targets: [
         .target(name: "ConsoleKit", dependencies: [
             .product(name: "Logging", package: "swift-log"),
+            .product(name: "NIOConcurrencyHelpers", package: "swift-nio")
         ]),
         .testTarget(name: "ConsoleKitTests", dependencies: [
             .target(name: "ConsoleKit"),
@@ -33,6 +35,10 @@ let package = Package(
         ]),
         .executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
             .target(name: "ConsoleKit")
+        ]),
+        .executableTarget(name: "ConsoleLoggerExample", dependencies: [
+            .target(name: "ConsoleKit"),
+            .product(name: "Logging", package: "swift-log")
         ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
 		.executableTarget(name: "ConsoleKitExample", dependencies: [
 			.target(name: "ConsoleKit"),
 		]),
-		.target(name: "ConsoleKitAsyncExample", dependencies: [
+		.executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
 			.target(name: "ConsoleKit")
 		])
 	]

--- a/Package.swift
+++ b/Package.swift
@@ -22,17 +22,17 @@ let package = Package(
         .testTarget(name: "ConsoleKitTests", dependencies: [
             .target(name: "ConsoleKit"),
         ]),
-		.testTarget(name: "AsyncConsoleKitTests", dependencies: [
-			.target(name: "ConsoleKit"),
-		]),
-		.testTarget(name: "ConsoleKitPerformanceTests", dependencies: [
-			.target(name: "ConsoleKit")
-		]),
-		.executableTarget(name: "ConsoleKitExample", dependencies: [
-			.target(name: "ConsoleKit"),
-		]),
-		.executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
-			.target(name: "ConsoleKit")
-		])
-	]
+        .testTarget(name: "AsyncConsoleKitTests", dependencies: [
+            .target(name: "ConsoleKit"),
+        ]),
+        .testTarget(name: "ConsoleKitPerformanceTests", dependencies: [
+            .target(name: "ConsoleKit")
+        ]),
+        .executableTarget(name: "ConsoleKitExample", dependencies: [
+            .target(name: "ConsoleKit"),
+        ]),
+        .executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
+            .target(name: "ConsoleKit")
+        ])
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -22,14 +22,17 @@ let package = Package(
         .testTarget(name: "ConsoleKitTests", dependencies: [
             .target(name: "ConsoleKit"),
         ]),
-        .testTarget(name: "AsyncConsoleKitTests", dependencies: [
-            .target(name: "ConsoleKit"),
-        ]),
-        .executableTarget(name: "ConsoleKitExample", dependencies: [
-            .target(name: "ConsoleKit"),
-        ]),
-        .target(name: "ConsoleKitAsyncExample", dependencies: [
-            .target(name: "ConsoleKit")
-        ])
-    ]
+		.testTarget(name: "AsyncConsoleKitTests", dependencies: [
+			.target(name: "ConsoleKit"),
+		]),
+		.testTarget(name: "ConsoleKitPerformanceTests", dependencies: [
+			.target(name: "ConsoleKit")
+		]),
+		.executableTarget(name: "ConsoleKitExample", dependencies: [
+			.target(name: "ConsoleKit"),
+		]),
+		.target(name: "ConsoleKitAsyncExample", dependencies: [
+			.target(name: "ConsoleKit")
+		])
+	]
 )

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.8
+import PackageDescription
+
+let package = Package(
+	name: "console-kit",
+	platforms: [
+		.macOS(.v10_15),
+		.iOS(.v13),
+		.watchOS(.v6),
+		.tvOS(.v13),
+	],
+	products: [
+		.library(name: "ConsoleKit", targets: ["ConsoleKit"]),
+	],
+	dependencies: [
+		.package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
+		.package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0")
+	],
+	targets: [
+		.target(name: "ConsoleKit", dependencies: [
+			.product(name: "Logging", package: "swift-log"),
+			.product(name: "Atomics", package: "swift-atomics")
+		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+		.testTarget(name: "ConsoleKitTests", dependencies: [
+			.target(name: "ConsoleKit"),
+		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+		.testTarget(name: "AsyncConsoleKitTests", dependencies: [
+			.target(name: "ConsoleKit"),
+		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+		.testTarget(name: "ConsoleKitPerformanceTests", dependencies: [
+			.target(name: "ConsoleKit")
+		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+		.executableTarget(name: "ConsoleKitExample", dependencies: [
+			.target(name: "ConsoleKit"),
+		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+		.executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
+			.target(name: "ConsoleKit")
+		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")])
+	]
+)

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -2,37 +2,37 @@
 import PackageDescription
 
 let package = Package(
-	name: "console-kit",
-	platforms: [
-		.macOS(.v10_15),
-		.iOS(.v13),
-		.watchOS(.v6),
-		.tvOS(.v13),
-	],
-	products: [
-		.library(name: "ConsoleKit", targets: ["ConsoleKit"]),
-	],
-	dependencies: [
-		.package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-	],
-	targets: [
-		.target(name: "ConsoleKit", dependencies: [
-			.product(name: "Logging", package: "swift-log"),
-		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
-		.testTarget(name: "ConsoleKitTests", dependencies: [
-			.target(name: "ConsoleKit"),
-		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
-		.testTarget(name: "AsyncConsoleKitTests", dependencies: [
-			.target(name: "ConsoleKit"),
-		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
-		.testTarget(name: "ConsoleKitPerformanceTests", dependencies: [
-			.target(name: "ConsoleKit")
-		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
-		.executableTarget(name: "ConsoleKitExample", dependencies: [
-			.target(name: "ConsoleKit"),
-		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
-		.executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
-			.target(name: "ConsoleKit")
-		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")])
-	]
+    name: "console-kit",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+    ],
+    products: [
+        .library(name: "ConsoleKit", targets: ["ConsoleKit"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
+    ],
+    targets: [
+        .target(name: "ConsoleKit", dependencies: [
+            .product(name: "Logging", package: "swift-log"),
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+        .testTarget(name: "ConsoleKitTests", dependencies: [
+            .target(name: "ConsoleKit"),
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+        .testTarget(name: "AsyncConsoleKitTests", dependencies: [
+            .target(name: "ConsoleKit"),
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+        .testTarget(name: "ConsoleKitPerformanceTests", dependencies: [
+            .target(name: "ConsoleKit")
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+        .executableTarget(name: "ConsoleKitExample", dependencies: [
+            .target(name: "ConsoleKit"),
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+        .executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
+            .target(name: "ConsoleKit")
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")])
+    ]
 )

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -14,12 +14,10 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-		.package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0")
 	],
 	targets: [
 		.target(name: "ConsoleKit", dependencies: [
 			.product(name: "Logging", package: "swift-log"),
-			.product(name: "Atomics", package: "swift-atomics")
 		], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
 		.testTarget(name: "ConsoleKitTests", dependencies: [
 			.target(name: "ConsoleKit"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -14,11 +14,18 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
     ],
     targets: [
         .target(name: "ConsoleKit", dependencies: [
             .product(name: "Logging", package: "swift-log"),
-        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+            .product(name: "NIOConcurrencyHelpers", package: "swift-nio")
+        ], swiftSettings: [
+            .enableExperimentalFeature("StrictConcurrency=complete"),
+            .enableUpcomingFeature("ExistentialAny"),
+            .enableUpcomingFeature("ForwardTrailingClosures"),
+            .enableUpcomingFeature("ConciseMagicFile"),
+        ]),
         .testTarget(name: "ConsoleKitTests", dependencies: [
             .target(name: "ConsoleKit"),
         ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
@@ -33,6 +40,10 @@ let package = Package(
         ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
         .executableTarget(name: "ConsoleKitAsyncExample", dependencies: [
             .target(name: "ConsoleKit")
-        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")])
+        ], swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]),
+        .executableTarget(name: "ConsoleLoggerExample", dependencies: [
+            .target(name: "ConsoleKit"),
+            .product(name: "Logging", package: "swift-log")
+        ])
     ]
 )

--- a/Sources/ConsoleKit/Activity/ActivityBar.swift
+++ b/Sources/ConsoleKit/Activity/ActivityBar.swift
@@ -1,5 +1,3 @@
-import Atomics
-
 /// An `ActivityIndicatorType` that renders an activity bar on a single line.
 ///
 ///     Title [=======              ]
@@ -28,7 +26,7 @@ extension ActivityBar {
         let bar: ConsoleText
         switch state {
         case .ready: bar = "[]"
-        case .active(let tick): bar = renderActiveBar(tick: tick, width: Self.width)
+        case .active(let tick): bar = renderActiveBar(tick: tick, width: console.activityBarWidth)
         case .success: bar = "[Done]".consoleText(.success)
         case .failure: bar = "[Failed]".consoleText(.error)
         }
@@ -36,13 +34,29 @@ extension ActivityBar {
     }
 }
 
-/// Defines the width of all `ActivityBar`s in characters.
-private let _width: ManagedAtomic<Int> = ManagedAtomic(25)
-
 extension ActivityBar {
-    /// Defines the width of all `ActivityBar`s in characters.
+    @available(*, deprecated, message: "This value has no effect. Use `console.activityBarWidth` instead.")
     public static var width: Int {
-		get { return _width.load(ordering: .relaxed) }
-		set { _width.store(newValue, ordering: .relaxed)}
+        get { 25 } // deliberately hardcoded value
+        set { } // deliberately ignore new value
+    }
+}
+
+/// Key type for storing the activity bar width in the `userInfo` of the related `Console` without colliding with end user keys.
+struct ActivityBarWidthKey: Hashable, Equatable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine("ConsoleKit.ActivityBarWidthKey")
+    }
+}
+
+extension Console {
+    public var activityBarWidth: Int {
+        get {
+            self.userInfo[AnyHashable(ActivityBarWidthKey())] as? Int ?? 25
+        }
+        
+        set {
+            self.userInfo[AnyHashable(ActivityBarWidthKey())] = newValue
+        }
     }
 }

--- a/Sources/ConsoleKit/Activity/ActivityBar.swift
+++ b/Sources/ConsoleKit/Activity/ActivityBar.swift
@@ -22,7 +22,7 @@ public protocol ActivityBar: ActivityIndicatorType {
 
 extension ActivityBar {
     /// See `ActivityIndicatorType`.
-    public func outputActivityIndicator(to console: Console, state: ActivityIndicatorState) {
+    public func outputActivityIndicator(to console: any Console, state: ActivityIndicatorState) {
         let bar: ConsoleText
         switch state {
         case .ready: bar = "[]"
@@ -52,11 +52,11 @@ struct ActivityBarWidthKey: Hashable, Equatable {
 extension Console {
     public var activityBarWidth: Int {
         get {
-            self.userInfo[AnyHashable(ActivityBarWidthKey())] as? Int ?? 25
+            self.userInfo[AnySendableHashable(ActivityBarWidthKey())] as? Int ?? 25
         }
         
         set {
-            self.userInfo[AnyHashable(ActivityBarWidthKey())] = newValue
+            self.userInfo[AnySendableHashable(ActivityBarWidthKey())] = newValue
         }
     }
 }

--- a/Sources/ConsoleKit/Activity/ActivityBar.swift
+++ b/Sources/ConsoleKit/Activity/ActivityBar.swift
@@ -1,3 +1,5 @@
+import Atomics
+
 /// An `ActivityIndicatorType` that renders an activity bar on a single line.
 ///
 ///     Title [=======              ]
@@ -35,12 +37,12 @@ extension ActivityBar {
 }
 
 /// Defines the width of all `ActivityBar`s in characters.
-private var _width: Int = 25
+private let _width: ManagedAtomic<Int> = ManagedAtomic(25)
 
 extension ActivityBar {
     /// Defines the width of all `ActivityBar`s in characters.
     public static var width: Int {
-        get { return _width }
-        set { _width = newValue}
+		get { return _width.load(ordering: .relaxed) }
+		set { _width.store(newValue, ordering: .relaxed)}
     }
 }

--- a/Sources/ConsoleKit/Activity/ActivityIndicator.swift
+++ b/Sources/ConsoleKit/Activity/ActivityIndicator.swift
@@ -77,7 +77,7 @@ public final class ActivityIndicator<A>: Sendable where A: ActivityIndicatorType
         self.state = NIOLockedValueBox(.ready)
         self._activity = NIOLockedValueBox(activity)
         self.queue = DispatchQueue(label: "codes.vapor.consolekit.activityindicator", target: targetQueue)
-        self._timer = NIOLockedValueBox(DispatchSource.makeTimerSource(flags: [], queue: self.queue))
+        self._timer = NIOLockedValueBox(DispatchSource.makeTimerSource(flags: [], queue: self.queue) as! DispatchSource)
         self.stopGroup = DispatchGroup()
     }
 

--- a/Sources/ConsoleKit/Activity/ActivityIndicator.swift
+++ b/Sources/ConsoleKit/Activity/ActivityIndicator.swift
@@ -33,7 +33,7 @@ extension ActivityIndicatorType {
 ///     // start the loading bar and wait for it to finish
 ///     try loadingBar.start(on: ...).wait()
 ///
-public final class ActivityIndicator<A> where A: ActivityIndicatorType {
+public final class ActivityIndicator<A>: Sendable where A: ActivityIndicatorType {
     /// The generic `ActivityIndicatorType` powering this `ActivityIndicator`.
     public var activity: A
 

--- a/Sources/ConsoleKit/Activity/ActivityIndicatorRenderer.swift
+++ b/Sources/ConsoleKit/Activity/ActivityIndicatorRenderer.swift
@@ -14,5 +14,5 @@ public protocol ActivityIndicatorType: Sendable {
     /// - parameters:
     ///     - console: `Console` to output this indicator to.
     ///     - state: State to draw the indicator in, e.g., active, failed.
-    func outputActivityIndicator(to console: Console, state: ActivityIndicatorState)
+    func outputActivityIndicator(to console: any Console, state: ActivityIndicatorState)
 }

--- a/Sources/ConsoleKit/Activity/ActivityIndicatorRenderer.swift
+++ b/Sources/ConsoleKit/Activity/ActivityIndicatorRenderer.swift
@@ -5,7 +5,7 @@
 /// behind calling the `ActivityIndicatorType` for `ActivityIndicatorState` changes.
 ///
 /// See the `ActivityBar` protocol which is based off of this protocol.
-public protocol ActivityIndicatorType {
+public protocol ActivityIndicatorType: Sendable {
     /// Draws / renders this `ActivityIndicatorType` to the `Console` for the supplied `ActivityIndicatorState`.
     ///
     /// This method will be called by the `ActivityIndicator`. The `Console` will have any previous

--- a/Sources/ConsoleKit/Activity/ActivityIndicatorState.swift
+++ b/Sources/ConsoleKit/Activity/ActivityIndicatorState.swift
@@ -1,7 +1,7 @@
 /// Possible states to draw / render and `ActivityIndicatorType`.
 ///
 /// See `ActivityIndicatorType`.
-public enum ActivityIndicatorState {
+public enum ActivityIndicatorState: Sendable {
     /// Default state. This is usually never used other than for initialization.
     case ready
 

--- a/Sources/ConsoleKit/Activity/CustomActivity.swift
+++ b/Sources/ConsoleKit/Activity/CustomActivity.swift
@@ -100,7 +100,7 @@ public struct CustomActivity: ActivityIndicatorType {
     
     
     /// See `ActivityIndicatorType.outputActivityIndicator(to:state:)`.
-    public func outputActivityIndicator(to console: Console, state: ActivityIndicatorState) {
+    public func outputActivityIndicator(to console: any Console, state: ActivityIndicatorState) {
         let output: ConsoleText
         
         switch state {

--- a/Sources/ConsoleKit/Activity/LoadingBar.swift
+++ b/Sources/ConsoleKit/Activity/LoadingBar.swift
@@ -42,7 +42,7 @@ public struct LoadingBar: ActivityBar {
         let reverse = Int(tick) % (period * 2) >= period
 
         let increasing = offset
-        let decreasing = LoadingBar.width - offset - 1
+        let decreasing = width - offset - 1
 
         let left: Int
         let right: Int

--- a/Sources/ConsoleKit/Activity/ProgressBar.swift
+++ b/Sources/ConsoleKit/Activity/ProgressBar.swift
@@ -51,8 +51,8 @@ public struct ProgressBar: ActivityBar {
     public func renderActiveBar(tick: UInt, width: Int) -> ConsoleText {
         let current = min(max(currentProgress, 0.0), 1.0)
 
-        let left = Int(current * Double(ProgressBar.width))
-        let right = ProgressBar.width - left
+        let left = Int(current * Double(width))
+        let right = width - left
 
         var barComponents: [String] = []
         barComponents.append("[")

--- a/Sources/ConsoleKit/Command/Async/AnyAsyncCommand.swift
+++ b/Sources/ConsoleKit/Command/Async/AnyAsyncCommand.swift
@@ -1,5 +1,5 @@
 /// A type-erased `Command`.
-public protocol AnyAsyncCommand {
+public protocol AnyAsyncCommand: Sendable {
     /// Text that will be displayed when `--help` is passed.
     var help: String { get }
     

--- a/Sources/ConsoleKit/Command/Async/AsyncCommandGroup.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommandGroup.swift
@@ -14,12 +14,12 @@
 ///
 /// You can create your own `AsyncCommandGroup` if you want to support custom `CommandOptions`.
 public protocol AsyncCommandGroup: AnyAsyncCommand {
-    var commands: [String: AnyAsyncCommand] { get }
-    var defaultCommand: AnyAsyncCommand? { get }
+    var commands: [String: any AnyAsyncCommand] { get }
+    var defaultCommand: (any AnyAsyncCommand)? { get }
 }
 
 extension AsyncCommandGroup {
-    public var defaultCommand: AnyAsyncCommand? {
+    public var defaultCommand: (any AnyAsyncCommand)? {
         return nil
     }
 }
@@ -80,7 +80,7 @@ extension AsyncCommandGroup {
         context.console.output(" [--help,-h]".consoleText(.success) + "` for more information on a command.")
     }
 
-    private func commmand(using context: inout CommandContext) throws -> AnyAsyncCommand? {
+    private func commmand(using context: inout CommandContext) throws -> (any AnyAsyncCommand)? {
         if let name = context.input.arguments.popFirst() {
             guard let command = self.commands[name] else {
                 throw CommandError.unknownCommand(name, available: Array(self.commands.keys))

--- a/Sources/ConsoleKit/Command/Async/AsyncCommands.swift
+++ b/Sources/ConsoleKit/Command/Async/AsyncCommands.swift
@@ -1,10 +1,10 @@
 /// Represents a top-level group of configured commands. This is usually created by calling `resolve(for:)` on `AsyncCommands`.
 public struct AsyncCommands {
     /// Top-level available commands, stored by unique name.
-    public var commands: [String: AnyAsyncCommand]
+    public var commands: [String: any AnyAsyncCommand]
 
     /// If set, this is the default top-level command that should run if no other commands are specified.
-    public var defaultCommand: AnyAsyncCommand?
+    public var defaultCommand: (any AnyAsyncCommand)?
 
     /// If `true`, an `autocomplete` subcommand will be added to any created `AsyncCommandGroup`.
     ///
@@ -30,8 +30,8 @@ public struct AsyncCommands {
     ///       automatically be included in the completion script generation process.
     ///
     public init(
-        commands: [String: AnyAsyncCommand] = [:],
-        defaultCommand: AnyAsyncCommand? = nil,
+        commands: [String: any AnyAsyncCommand] = [:],
+        defaultCommand: (any AnyAsyncCommand)? = nil,
         enableAutocomplete: Bool = false
     ) {
         self.commands = commands
@@ -49,7 +49,7 @@ public struct AsyncCommands {
     ///     - name: A unique name for running this command.
     ///     - isDefault: If `true`, this command will be set as the default command to run when none other are specified.
     ///                  Setting this overrides any previous default commands.
-    public mutating func use(_ command: AnyAsyncCommand, as name: String, isDefault: Bool = false) {
+    public mutating func use(_ command: any AnyAsyncCommand, as name: String, isDefault: Bool = false) {
         self.commands[name] = command
         if isDefault {
             self.defaultCommand = command
@@ -67,7 +67,7 @@ public struct AsyncCommands {
     /// - parameters:
     ///     - help: Optional help messages to include.
     /// - returns: An `AsyncCommandGroup` with commands and defaultCommand configured.
-    public func group(help: String = "") -> AsyncCommandGroup {
+    public func group(help: String = "") -> any AsyncCommandGroup {
         var group = _AsyncGroup(
             commands: self.commands,
             defaultCommand: self.defaultCommand,
@@ -85,7 +85,7 @@ public struct AsyncCommands {
 }
 
 private struct _AsyncGroup: AsyncCommandGroup {
-    var commands: [String: AnyAsyncCommand]
-    var defaultCommand: AnyAsyncCommand?
+    var commands: [String: any AnyAsyncCommand]
+    var defaultCommand: (any AnyAsyncCommand)?
     let help: String
 }

--- a/Sources/ConsoleKit/Command/CommandContext.swift
+++ b/Sources/ConsoleKit/Command/CommandContext.swift
@@ -1,7 +1,7 @@
 /// A type-erased `CommandContext`
 public struct CommandContext {
     /// The `Console` this command was run on.
-    public var console: Console
+    public var console: any Console
     
     /// The parsed arguments (according to declared signature).
     public var input: CommandInput
@@ -10,7 +10,7 @@ public struct CommandContext {
     
     /// Create a new `AnyCommandContext`.
     public init(
-        console: Console,
+        console: any Console,
         input: CommandInput
     ) {
         self.console = console

--- a/Sources/ConsoleKit/Command/CommandGroup.swift
+++ b/Sources/ConsoleKit/Command/CommandGroup.swift
@@ -14,12 +14,12 @@
 ///
 /// You can create your own `CommandGroup` if you want to support custom `CommandOptions`.
 public protocol CommandGroup: AnyCommand {
-    var commands: [String: AnyCommand] { get }
-    var defaultCommand: AnyCommand? { get }
+    var commands: [String: any AnyCommand] { get }
+    var defaultCommand: (any AnyCommand)? { get }
 }
 
 extension CommandGroup {
-    public var defaultCommand: AnyCommand? {
+    public var defaultCommand: (any AnyCommand)? {
         return nil
     }
 }
@@ -80,7 +80,7 @@ extension CommandGroup {
         context.console.output(" [--help,-h]".consoleText(.success) + "` for more information on a command.")
     }
 
-    private func commmand(using context: inout CommandContext) throws -> AnyCommand? {
+    private func commmand(using context: inout CommandContext) throws -> (any AnyCommand)? {
         if let name = context.input.arguments.popFirst() {
             guard let command = self.commands[name] else {
                 throw CommandError.unknownCommand(name, available: Array(self.commands.keys))

--- a/Sources/ConsoleKit/Command/CommandInput.swift
+++ b/Sources/ConsoleKit/Command/CommandInput.swift
@@ -1,5 +1,5 @@
 /// Raw input for commands. Use this to parse options and arguments for the command context.
-public struct CommandInput {
+public struct CommandInput: Sendable {
     /// The `CommandInput`'s raw arguments. This array will be mutated as arguments and options
     /// are parsed from the `CommandInput`.
     public var arguments: [String]

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -15,24 +15,24 @@ extension CommandSignature {
         return reference
     }
 
-    var arguments: [AnyArgument] {
+    var arguments: [any AnyArgument] {
         return Mirror(reflecting: self).children
-            .compactMap { $0.value as? AnyArgument }
+            .compactMap { $0.value as? (any AnyArgument) }
     }
 
-    var options: [AnyOption] {
+    var options: [any AnyOption] {
         return Mirror(reflecting: self).children
-            .compactMap { $0.value as? AnyOption }
+            .compactMap { $0.value as? (any AnyOption) }
     }
 
-    var flags: [AnyFlag] {
+    var flags: [any AnyFlag] {
         return Mirror(reflecting: self).children
-            .compactMap { $0.value as? AnyFlag }
+            .compactMap { $0.value as? (any AnyFlag) }
     }
 
-    var values: [AnySignatureValue] {
+    var values: [any AnySignatureValue] {
         return Mirror(reflecting: self).children
-            .compactMap { $0.value as? AnySignatureValue }
+            .compactMap { $0.value as? (any AnySignatureValue) }
     }
     
     public init(from input: inout CommandInput) throws {

--- a/Sources/ConsoleKit/Command/Commands.swift
+++ b/Sources/ConsoleKit/Command/Commands.swift
@@ -1,10 +1,10 @@
 /// Represents a top-level group of configured commands. This is usually created by calling `resolve(for:)` on `Commands`.
 public struct Commands {
     /// Top-level available commands, stored by unique name.
-    public var commands: [String: AnyCommand]
+    public var commands: [String: any AnyCommand]
 
     /// If set, this is the default top-level command that should run if no other commands are specified.
-    public var defaultCommand: AnyCommand?
+    public var defaultCommand: (any AnyCommand)?
 
     /// If `true`, an `autocomplete` subcommand will be added to any created `CommandGroup`.
     ///
@@ -29,7 +29,7 @@ public struct Commands {
     ///       `enableAutocomplete` should only be set to `true` for a _root_ command group. Any nested subcommands will
     ///       automatically be included in the completion script generation process.
     ///
-    public init(commands: [String: AnyCommand] = [:], defaultCommand: AnyCommand? = nil, enableAutocomplete: Bool = false) {
+    public init(commands: [String: any AnyCommand] = [:], defaultCommand: (any AnyCommand)? = nil, enableAutocomplete: Bool = false) {
         self.commands = commands
         self.defaultCommand = defaultCommand
         self.enableAutocomplete = enableAutocomplete
@@ -45,7 +45,7 @@ public struct Commands {
     ///     - name: A unique name for running this command.
     ///     - isDefault: If `true`, this command will be set as the default command to run when none other are specified.
     ///                  Setting this overrides any previous default commands.
-    public mutating func use(_ command: AnyCommand, as name: String, isDefault: Bool = false) {
+    public mutating func use(_ command: any AnyCommand, as name: String, isDefault: Bool = false) {
         self.commands[name] = command
         if isDefault {
             self.defaultCommand = command
@@ -63,7 +63,7 @@ public struct Commands {
     /// - parameters:
     ///     - help: Optional help messages to include.
     /// - returns: A `CommandGroup` with commands and defaultCommand configured.
-    public func group(help: String = "") -> CommandGroup {
+    public func group(help: String = "") -> any CommandGroup {
         var group = _Group(
             commands: self.commands,
             defaultCommand: self.defaultCommand,
@@ -81,7 +81,7 @@ public struct Commands {
 }
 
 private struct _Group: CommandGroup {
-    var commands: [String: AnyCommand]
-    var defaultCommand: AnyCommand?
+    var commands: [String: any AnyCommand]
+    var defaultCommand: (any AnyCommand)?
     let help: String
 }

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -121,8 +121,8 @@ extension AnyCommand {
     /// Returns the bash completion function for `self`.
     fileprivate func renderBashCompletionFunction(
         using context: CommandContext,
-        signatureValues: [AnySignatureValue] = [],
-        subcommands: [String: AnyCommand] = [:]
+        signatureValues: [any AnySignatureValue] = [],
+        subcommands: [String: any AnyCommand] = [:]
     ) -> String {
         let commandDepth = context.input.executablePath.count
         let isRootCommand = commandDepth == 1
@@ -224,8 +224,8 @@ extension AnyCommand {
     ///
     fileprivate func renderZshCompletionFunction(
         using context: CommandContext,
-        signatureValues: [AnySignatureValue] = [],
-        subcommands: [String: AnyCommand] = [:]
+        signatureValues: [any AnySignatureValue] = [],
+        subcommands: [String: any AnyCommand] = [:]
     ) -> String {
         let arguments = ([Flag.help] + signatureValues.sorted(by: { $0.name < $1.name })).map { $0.completionInfo }
         let subcommands = subcommands.sorted(by: { $0.key < $1.key })
@@ -298,8 +298,8 @@ extension AnyAsyncCommand {
     /// Returns the bash completion function for `self`.
     fileprivate func renderBashCompletionFunction(
         using context: CommandContext,
-        signatureValues: [AnySignatureValue] = [],
-        subcommands: [String: AnyAsyncCommand] = [:]
+        signatureValues: [any AnySignatureValue] = [],
+        subcommands: [String: any AnyAsyncCommand] = [:]
     ) -> String {
         let commandDepth = context.input.executablePath.count
         let isRootCommand = commandDepth == 1
@@ -401,8 +401,8 @@ extension AnyAsyncCommand {
     ///
     fileprivate func renderZshCompletionFunction(
         using context: CommandContext,
-        signatureValues: [AnySignatureValue] = [],
-        subcommands: [String: AnyAsyncCommand] = [:]
+        signatureValues: [any AnySignatureValue] = [],
+        subcommands: [String: any AnyAsyncCommand] = [:]
     ) -> String {
         let arguments = ([Flag.help] + signatureValues.sorted(by: { $0.name < $1.name })).map { $0.completionInfo }
         let subcommands = subcommands.sorted(by: { $0.key < $1.key })

--- a/Sources/ConsoleKit/Command/Console+Run.swift
+++ b/Sources/ConsoleKit/Command/Console+Run.swift
@@ -10,7 +10,7 @@ extension Console {
     /// - parameters:
     ///     - command: `CommandGroup` or `Command` to run.
     ///     - input: `CommandInput` to parse `CommandOption`s and `CommandArgument`s from.
-    public func run(_ command: AnyCommand, input: CommandInput) throws {
+    public func run(_ command: any AnyCommand, input: CommandInput) throws {
         // create new context
         try self.run(command, with: CommandContext(console: self, input: input))
     }
@@ -22,7 +22,7 @@ extension Console {
     /// - parameters:
     ///     - runnable: `CommandGroup` or `Command` to run.
     ///     - input: `CommandContext` to parse `CommandOption`s and `CommandArgument`s from.
-    public func run(_ command: AnyCommand, with context: CommandContext) throws {
+    public func run(_ command: any AnyCommand, with context: CommandContext) throws {
         // make copy of context
         var context = context
 
@@ -55,7 +55,7 @@ extension Console {
     /// - parameters:
     ///     - command: `AsyncCommandGroup` or `AsyncCommand` to run.
     ///     - input: `CommandInput` to parse `CommandOption`s and `CommandArgument`s from.
-    public func run(_ command: AnyAsyncCommand, input: CommandInput) async throws {
+    public func run(_ command: any AnyAsyncCommand, input: CommandInput) async throws {
         // create new context
         try await self.run(command, with: CommandContext(console: self, input: input))
     }
@@ -67,7 +67,7 @@ extension Console {
     /// - parameters:
     ///     - runnable: `AsyncCommandGroup` or `AsyncCommand` to run.
     ///     - input: `CommandContext` to parse `CommandOption`s and `CommandArgument`s from.
-    public func run(_ command: AnyAsyncCommand, with context: CommandContext) async throws {
+    public func run(_ command: any AnyAsyncCommand, with context: CommandContext) async throws {
         // make copy of context
         var context = context
 

--- a/Sources/ConsoleKit/Console.swift
+++ b/Sources/ConsoleKit/Console.swift
@@ -75,5 +75,5 @@ public protocol Console: AnyObject, Sendable {
     ///     - newLine: If `true`, the next error will be on a new line.
     func report(error: String, newLine: Bool)
     
-    var userInfo: [AnyHashable: Sendable] { get set }
+    var userInfo: [AnySendableHashable: any Sendable] { get set }
 }

--- a/Sources/ConsoleKit/Console.swift
+++ b/Sources/ConsoleKit/Console.swift
@@ -34,7 +34,7 @@
 ///
 /// Get the `Console`'s current size using the `size` property.
 ///
-public protocol Console: AnyObject {
+public protocol Console: AnyObject, Sendable {
     /// The size of the `Console` window. Used for calculating lines printed and centering text.
     var size: (width: Int, height: Int) { get }
 
@@ -75,5 +75,5 @@ public protocol Console: AnyObject {
     ///     - newLine: If `true`, the next error will be on a new line.
     func report(error: String, newLine: Bool)
     
-    var userInfo: [AnyHashable: Any] { get set } 
+    var userInfo: [AnyHashable: Sendable] { get set }
 }

--- a/Sources/ConsoleKit/Output/ConsoleColor.swift
+++ b/Sources/ConsoleKit/Output/ConsoleColor.swift
@@ -4,7 +4,7 @@
 ///         basically because "that's how ANSI colors work". It's a little conceptually weird, but so are terminal
 ///         control codes.
 ///
-public enum ConsoleColor {
+public enum ConsoleColor: Sendable {
     // MARK: Normal
 
     /// Black

--- a/Sources/ConsoleKit/Output/ConsoleStyle.swift
+++ b/Sources/ConsoleKit/Output/ConsoleStyle.swift
@@ -1,6 +1,6 @@
 /// Representation of a style for outputting to a Console in different colors with differing attributes.
 /// A few suggested default styles are provided.
-public struct ConsoleStyle {
+public struct ConsoleStyle: Sendable {
     /// Optional text color. If `nil`, text is plain.
     public let color: ConsoleColor?
 

--- a/Sources/ConsoleKit/Output/ConsoleText.swift
+++ b/Sources/ConsoleKit/Output/ConsoleText.swift
@@ -25,7 +25,7 @@ extension String {
 ///     let text: ConsoleText = "Hello, " + "world".consoleText(color: .green)
 ///
 /// See `Console.output(_:newLine:)` for more information.
-public struct ConsoleText: RandomAccessCollection, ExpressibleByArrayLiteral, ExpressibleByStringLiteral, CustomStringConvertible {
+public struct ConsoleText: RandomAccessCollection, ExpressibleByArrayLiteral, ExpressibleByStringLiteral, CustomStringConvertible, Sendable {
     /// See `Collection`.
     public var startIndex: Int {
         return fragments.startIndex

--- a/Sources/ConsoleKit/Output/ConsoleTextFragment.swift
+++ b/Sources/ConsoleKit/Output/ConsoleTextFragment.swift
@@ -1,5 +1,5 @@
 /// A single piece of `ConsoleText`. Contains a raw `String` and the desired `ConsoleStyle`.
-public struct ConsoleTextFragment {
+public struct ConsoleTextFragment: Sendable {
     /// The raw `String`.
     public var string: String
 

--- a/Sources/ConsoleKit/Terminal/ANSI.swift
+++ b/Sources/ConsoleKit/Terminal/ANSI.swift
@@ -156,7 +156,7 @@ extension ANSISGRColorSpec {
         case .traditional(let c): return .foregroundColor(c)
         case .bright(let c): return .brightForegroundColor(c)
         case .palette(let c): return .paletteForegroundColor(c)
-        case .rgb(let r, let g, let b):	return .rgbForegroundColor(r: r, g: g, b: b)
+        case .rgb(let r, let g, let b): return .rgbForegroundColor(r: r, g: g, b: b)
         case .`default`: return .defaultForegroundColor
         }
     }
@@ -178,7 +178,7 @@ extension ConsoleStyle {
         var commands: [ANSISGRCommand] = [.reset]
         
         if isBold {
-	        commands.append(.bold)
+            commands.append(.bold)
         }
         if let color = color {
             commands.append(color.ansiSpec.foregroundAnsiCommand)

--- a/Sources/ConsoleKit/Terminal/Terminal.swift
+++ b/Sources/ConsoleKit/Terminal/Terminal.swift
@@ -122,9 +122,13 @@ public final class Terminal: Console, Sendable {
 
     /// See `Console`
     public func report(error: String, newLine: Bool) {
-        let output = newLine ? error + "\n" : error
-        let data = output.data(using: .utf8) ?? Data()
-        FileHandle.standardError.write(data)
+        for c in (newLine ? "\(error)\n" : error).utf8 {
+#if os(Windows)
+            _putc_nolock(CInt(c), stderr)
+#else
+            putc_unlocked(CInt(c), stderr)
+#endif
+        }
     }
 
     /// See `Console`

--- a/Sources/ConsoleKit/Terminal/Terminal.swift
+++ b/Sources/ConsoleKit/Terminal/Terminal.swift
@@ -91,23 +91,23 @@ public final class Terminal: Console, Sendable {
 
     /// See `Console`
     public func output(_ text: ConsoleText, newLine: Bool) {
-		if self.enableCommands {
-			var lines = 0
-			for fragment in text.fragments {
-				let strings = fragment.string.split(separator: "\n", omittingEmptySubsequences: false)
-				for string in strings {
-					let count = string.count
-					if count > size.width && count > 0 && size.width > 0 {
-						lines += (count / size.width) + 1
-					}
-				}
-				/// add line for each fragment
-				lines += strings.count - 1
-			}
-			if newLine { lines += 1 }
-			
-			didOutputLines(count: lines)
-		}
+        if self.enableCommands {
+            var lines = 0
+            for fragment in text.fragments {
+                let strings = fragment.string.split(separator: "\n", omittingEmptySubsequences: false)
+                for string in strings {
+                    let count = string.count
+                    if count > size.width && count > 0 && size.width > 0 {
+                        lines += (count / size.width) + 1
+                    }
+                }
+                /// add line for each fragment
+                lines += strings.count - 1
+            }
+            if newLine { lines += 1 }
+            
+            didOutputLines(count: lines)
+        }
 
         let terminator = newLine ? "\n" : ""
 

--- a/Sources/ConsoleKit/Terminal/Terminal.swift
+++ b/Sources/ConsoleKit/Terminal/Terminal.swift
@@ -9,9 +9,9 @@ import Foundation
 
 /// Generic console that uses a mixture of Swift standard
 /// library and Foundation code to fulfill protocol requirements.
-public final class Terminal: Console {
+public final class Terminal: Console, Sendable {
     /// See `Console`
-    public var userInfo: [AnyHashable: Any]
+    public var userInfo: [AnyHashable: Sendable]
 
     /// Dynamically exclude ANSI commands when in Xcode since it doesn't support them.
     internal var enableCommands: Bool {

--- a/Sources/ConsoleKit/Terminal/Terminal.swift
+++ b/Sources/ConsoleKit/Terminal/Terminal.swift
@@ -91,7 +91,7 @@ public final class Terminal: Console, Sendable {
 
     /// See `Console`
     public func output(_ text: ConsoleText, newLine: Bool) {
-		if !self.enableCommands {
+		if self.enableCommands {
 			var lines = 0
 			for fragment in text.fragments {
 				let strings = fragment.string.split(separator: "\n", omittingEmptySubsequences: false)

--- a/Sources/ConsoleKit/Terminal/Terminal.swift
+++ b/Sources/ConsoleKit/Terminal/Terminal.swift
@@ -91,21 +91,23 @@ public final class Terminal: Console {
 
     /// See `Console`
     public func output(_ text: ConsoleText, newLine: Bool) {
-        var lines = 0
-        for fragment in text.fragments {
-            let strings = fragment.string.split(separator: "\n", omittingEmptySubsequences: false)
-            for string in strings {
-                let count = string.count
-                if count > size.width && count > 0 && size.width > 0 {
-                    lines += (count / size.width) + 1
-                }
-            }
-            /// add line for each fragment
-            lines += strings.count - 1
-        }
-        if newLine { lines += 1 }
-
-        didOutputLines(count: lines)
+		if !self.enableCommands {
+			var lines = 0
+			for fragment in text.fragments {
+				let strings = fragment.string.split(separator: "\n", omittingEmptySubsequences: false)
+				for string in strings {
+					let count = string.count
+					if count > size.width && count > 0 && size.width > 0 {
+						lines += (count / size.width) + 1
+					}
+				}
+				/// add line for each fragment
+				lines += strings.count - 1
+			}
+			if newLine { lines += 1 }
+			
+			didOutputLines(count: lines)
+		}
 
         let terminator = newLine ? "\n" : ""
 
@@ -116,7 +118,6 @@ public final class Terminal: Console {
             output = text.description
         }
         Swift.print(output, terminator: terminator)
-        fflush(stdout)
     }
 
     /// See `Console`

--- a/Sources/ConsoleKit/Terminal/readpassphrase_linux.swift
+++ b/Sources/ConsoleKit/Terminal/readpassphrase_linux.swift
@@ -49,26 +49,11 @@ internal func linux_readpassphrase(_ prompt: UnsafePointer<Int8>, _ buf: UnsafeM
     sigemptyset(&sigrecovery.sa_mask)
     sigrecovery.sa_flags = 0
     #if canImport(Darwin)
-	sigrecovery.__sigaction_u = .init(__sa_handler: {
-		linux_readpassphrase_signos.set(
-			linux_readpassphrase_signos.get($0) + 1,
-			at: $0
-		)
-	})
+    sigrecovery.__sigaction_u = .init(__sa_handler: { linux_readpassphrase_signos[$0] += 1 })
     #elseif os(Linux)
-    sigrecovery.__sigaction_handler = .init(sa_handler: {
-		linux_readpassphrase_signos.set(
-			linux_readpassphrase_signos.get($0) + 1,
-			at: $0
-		)
-	})
+    sigrecovery.__sigaction_handler = .init(sa_handler: { linux_readpassphrase_signos[$0] += 1 })
     #elseif os(Android)
-    sigrecovery.sa_handler = {
-		linux_readpassphrase_signos.set(
-			linux_readpassphrase_signos.get($0) + 1,
-			at: $0
-		)
-	}
+    sigrecovery.sa_handler = { linux_readpassphrase_signos[$0] += 1 }
     #endif
     for (sig, _) in sigsaves { sigaction(sig, &sigrecovery, &sigsave); sigsaves[sig] = sigsave }
     
@@ -90,7 +75,7 @@ internal func linux_readpassphrase(_ prompt: UnsafePointer<Int8>, _ buf: UnsafeM
         while tcsetattr(fd, TCSAFLUSH | TCSASOFT, &oterm) == -1 && errno == EINTR && linux_readpassphrase_signos[SIGTTOU] == 0 {
             continue
         }
-		linux_readpassphrase_signos.set(save_sigttou, at: SIGTTOU)
+        linux_readpassphrase_signos[SIGTTOU] = save_sigttou
     }
     
     // Restore signal handlers
@@ -138,30 +123,16 @@ fileprivate struct VeryUnsafeMutableSigAtomicBufferPointer {
         self.capacity = Int(capacity)
         self.baseAddress = .allocate(capacity: self.capacity)
     }
-	
-	func get(_ index: Int) -> sig_atomic_t {
-		self.baseAddress.advanced(by: index).pointee
-	}
-	
-	func set(_ value: sig_atomic_t, at index: Int) {
-		self.baseAddress.advanced(by: index).pointee = value
-	}
-	
-	func get(_ index: Int32) -> sig_atomic_t {
-		self.get(Int(index))
-	}
-	
-	func set(_ value: sig_atomic_t, at index: Int32) {
-		self.set(value, at: Int(index))
-	}
-	
-	subscript(_ index: Int) -> sig_atomic_t {
-		self.get(index)
-	}
-	
-	subscript(_ index: Int32) -> sig_atomic_t {
-		self.get(index)
-	}
+    
+    subscript(_ index: Int) -> sig_atomic_t {
+        get { self.baseAddress.advanced(by: index).pointee }
+        nonmutating set { self.baseAddress.advanced(by: index).pointee = newValue }
+    }
+
+    subscript(_ index: Int32) -> sig_atomic_t {
+        get { self[Int(index)] }
+        nonmutating set { self[Int(index)] = newValue }
+    }
     
     func reset() {
 #if swift(<5.8)

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -9,8 +9,10 @@ public func defaultLoggerFragment() -> some LoggerFragment {
 }
 
 /// A `LoggerFragment` which implements the default logger message format with a timestamp at the front.
-public func timestampDefaultLoggerFragment() -> some LoggerFragment {
-    TimestampFragment().and(defaultLoggerFragment().separated(" "))
+public func timestampDefaultLoggerFragment(
+    timestampSource: some TimestampSource = SystemTimestampSource()
+) -> some LoggerFragment {
+    TimestampFragment(timestampSource).and(defaultLoggerFragment().separated(" "))
 }
 
 /// Outputs logs to a `Console` via a `LoggerFragment` pipeline.

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -178,12 +178,29 @@ extension LoggingSystem {
     ///
     /// - Parameters:
     ///   - console: The console the logger will log the messages to.
-    ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
-    ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    public static func bootstrap(console: Console, level: Logger.Level = .info, metadata: Logger.Metadata = [:]) {
-        self.bootstrap { label in
-            return ConsoleLogger(label: label, console: console, level: level, metadata: metadata)
-        }
+    ///   - level: The minimum level of message that the logger will output. This defaults to `.info`.
+    ///   - metadata: Extra metadata to log with all messages. This defaults to an empty dictionary.
+    ///   - metadataProvider: The metadata provider to bootstrap the logging system with.
+    public static func bootstrap(console: Console, level: Logger.Level = .info, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider? = nil) {
+        self.bootstrap({ (label, metadataProvider) in
+            return ConsoleLogger(label: label, console: console, level: level, metadata: metadata, metadataProvider: metadataProvider)
+        }, metadataProvider: metadataProvider)
+    }
+    
+    /// Bootstraps a `ConsoleFragmentLogger` to the `LoggingSystem`, so that logger will be used in `Logger.init(label:)`.
+    ///
+    ///     LoggingSystem.boostrap(console: console)
+    ///
+    /// - Parameters:
+    ///   - fragment: The logger fragment which will be used to build the logged messages.
+    ///   - console: The console the logger will log the messages to.
+    ///   - level: The minimum level of message that the logger will output. This defaults to `.info`.
+    ///   - metadata: Extra metadata to log with all messages. This defaults to an empty dictionary.
+    ///   - metadataProvider: The metadata provider to bootstrap the logging system with.
+    public static func bootstrap<T: LoggerFragment>(fragment: T, console: Console, level: Logger.Level = .info, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider? = nil) {
+        self.bootstrap({ (label, metadataProvider) in
+            return ConsoleFragmentLogger(fragment: fragment, label: label, console: console, level: level, metadata: metadata, metadataProvider: metadataProvider)
+        }, metadataProvider: metadataProvider)
     }
 }
 

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -2,10 +2,10 @@ import Logging
 
 /// A `LoggerFragment` which implements the default logger message format.
 public func defaultLoggerFragment() -> some LoggerFragment {
-	LabelFragment().maxLevel(.trace)
+	TimestampFragment().and(LabelFragment().separated(" ")).maxLevel(.trace)
 		.and(LevelFragment().separated(" ").and(MessageFragment().separated(" ")))
 		.and(MetadataFragment().separated(" "))
-		.and(FileFragment().separated(" ").maxLevel(.debug))
+		.and(SourceLocationFragment().separated(" ").maxLevel(.debug))
 }
 
 /// Outputs logs to a `Console` via a `LoggerFragment` pipeline.

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -1,5 +1,114 @@
 import Logging
 
+/// splits a path on the /Sources/ folder, returning everything after
+///
+///     "/Users/developer/dev/MyApp/Sources/Run/main.swift"
+///     // becomes
+///     "Run/main.swift"
+///
+func conciseSourcePath(_ path: String) -> String {
+#if compiler(>=5.3)
+	return path
+#else
+	let separator: Substring = path.contains("Sources") ? "Sources" : "Tests"
+	return path.split(separator: "/")
+		.split(separator: separator)
+		.last?
+		.joined(separator: "/") ?? path
+#endif
+}
+
+/// A `LoggerFragment` which implements the default logger message format.
+public func defaultLoggerFragment() -> some LoggerFragment {
+	LabelFragment().maxLevel(.trace)
+		.and(LevelFragment().separated(" ").and(MessageFragment().separated(" ")))
+		.and(MetadataFragment().separated(" "))
+		.and(FileFragment().separated(" ").maxLevel(.debug))
+}
+
+/// Outputs logs to a `Console` via a `LoggerFragment` pipeline.
+public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler {
+	public let label: String
+	
+	/// See `LogHandler.metadata`.
+	public var metadata: Logger.Metadata
+	
+	/// See `LogHandler.metadataProvider`.
+	public var metadataProvider: Logger.MetadataProvider?
+	
+	/// See `LogHandler.logLevel`.
+	public var logLevel: Logger.Level
+	
+	/// The conosle that the messages will get logged to.
+	public let console: Console
+	
+	/// The `LoggerFragment` this logger outputs through.
+	public var fragment: T
+	
+	/// Creates a new `ConsoleLogger` instance.
+	///
+	/// - Parameters:
+	///   - fragment: The `LoggerFragment` this logger outputs through.
+	///   - label: Unique identifier for this logger.
+	///   - console: The console to log the messages to.
+	///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
+	///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
+	public init(fragment: T, label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
+		self.fragment = fragment
+		self.label = label
+		self.metadata = metadata
+		self.logLevel = level
+		self.console = console
+	}
+	
+	public init(fragment: T, label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+		self.fragment = fragment
+		self.label = label
+		self.metadata = metadata
+		self.logLevel = level
+		self.console = console
+		self.metadataProvider = metadataProvider
+	}
+	
+	/// See `LogHandler[metadataKey:]`.
+	///
+	/// This just acts as a getter/setter for the `.metadata` property.
+	public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+		get { return self.metadata[key] }
+		set { self.metadata[key] = newValue }
+	}
+	
+	/// See `LogHandler.log(level:message:metadata:source:file:function:line:)`.
+	public func log(
+		level: Logger.Level,
+		message: Logger.Message,
+		metadata: Logger.Metadata?,
+		source: String,
+		file: String,
+		function: String,
+		line: UInt
+	) {
+		var output = FragmentOutput()
+		var record = LogRecord(
+			level: level,
+			message: message,
+			metadata: metadata,
+			source: source,
+			file: file,
+			function: function,
+			line: line,
+			label: self.label,
+			loggerLevel: self.logLevel,
+			loggerMetadata: self.metadata,
+			metadataProvider: self.metadataProvider
+		)
+		
+		self.fragment.write(&record, to: &output)
+
+		self.console.output(output.text)
+	}
+}
+
 /// Outputs logs to a `Console`.
 public struct ConsoleLogger: LogHandler {
     public let label: String
@@ -15,6 +124,8 @@ public struct ConsoleLogger: LogHandler {
     
     /// The conosle that the messages will get logged to.
     public let console: Console
+	
+	public var fragment: some LoggerFragment = defaultLoggerFragment()
 
     /// Creates a new `ConsoleLogger` instance.
     ///
@@ -46,66 +157,35 @@ public struct ConsoleLogger: LogHandler {
         set { self.metadata[key] = newValue }
     }
     
-    /// See `LogHandler.log(level:message:metadata:file:function:line:)`.
+    /// See `LogHandler.log(level:message:metadata:source:file:function:line:)`.
     public func log(
         level: Logger.Level,
         message: Logger.Message,
         metadata: Logger.Metadata?,
+		source: String,
         file: String,
         function: String,
         line: UInt
     ) {
-        var text: ConsoleText = ""
-        
-        if self.logLevel <= .trace {
-            text += "[ \(self.label) ] ".consoleText()
-        }
-            
-        text += "[ \(level.name) ]".consoleText(level.style)
-            + " "
-            + message.description.consoleText()
+        var output = FragmentOutput()
 
-        let allMetadata = (metadata ?? [:])
-            .merging(self.metadata, uniquingKeysWith: { (a, _) in a })
-            .merging(self.metadataProvider?.get() ?? [:], uniquingKeysWith: { (a, _) in a })
+		var record = LogRecord(
+			level: level,
+			message: message,
+			metadata: metadata,
+			source: source,
+			file: file,
+			function: function,
+			line: line,
+			label: self.label,
+			loggerLevel: self.logLevel,
+			loggerMetadata: self.metadata,
+			metadataProvider: self.metadataProvider
+		)
+		
+		self.fragment.write(&record, to: &output)
 
-        if !allMetadata.isEmpty {
-            // only log metadata if not empty
-            text += " " + allMetadata.sortedDescriptionWithoutQuotes.consoleText()
-        }
-
-        // log file info if we are debug or lower
-        if self.logLevel <= .debug {
-            // log the concise path + line
-            let fileInfo = self.conciseSourcePath(file) + ":" + line.description
-            text += " (" + fileInfo.consoleText() + ")"
-        }
-
-        self.console.output(text)
-    }
-    
-    /// splits a path on the /Sources/ folder, returning everything after
-    ///
-    ///     "/Users/developer/dev/MyApp/Sources/Run/main.swift"
-    ///     // becomes
-    ///     "Run/main.swift"
-    ///
-    private func conciseSourcePath(_ path: String) -> String {
-        let separator: Substring = path.contains("Sources") ? "Sources" : "Tests"
-        return path.split(separator: "/")
-            .split(separator: separator)
-            .last?
-            .joined(separator: "/") ?? path
-    }
-}
-
-private extension Logger.Metadata {
-    var sortedDescriptionWithoutQuotes: String {
-        let contents = Array(self)
-            .sorted(by: { $0.0 < $1.0 })
-            .map { "\($0.description): \($1)" }
-            .joined(separator: ", ")
-        return "[\(contents)]"
+		self.console.output(output.text)
     }
 }
 

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -9,7 +9,7 @@ public func defaultLoggerFragment() -> some LoggerFragment {
 }
 
 /// Outputs logs to a `Console` via a `LoggerFragment` pipeline.
-public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler {
+public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler, Sendable {
 	public let label: String
 	
 	/// See `LogHandler.metadata`.
@@ -22,7 +22,7 @@ public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler {
 	public var logLevel: Logger.Level
 	
 	/// The conosle that the messages will get logged to.
-	public let console: Console
+	public let console: Console & Sendable
 	
 	/// The `LoggerFragment` this logger outputs through.
 	public var fragment: T
@@ -35,7 +35,7 @@ public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler {
 	///   - console: The console to log the messages to.
 	///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
 	///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-	public init(fragment: T, label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
+	public init(fragment: T, label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
 		self.fragment = fragment
 		self.label = label
 		self.metadata = metadata
@@ -43,7 +43,7 @@ public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler {
 		self.console = console
 	}
 	
-	public init(fragment: T, label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+	public init(fragment: T, label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
 		self.fragment = fragment
 		self.label = label
 		self.metadata = metadata
@@ -92,7 +92,7 @@ public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler {
 }
 
 /// Outputs logs to a `Console`.
-public struct ConsoleLogger: LogHandler {
+public struct ConsoleLogger: LogHandler, Sendable {
     public let label: String
     
     /// See `LogHandler.metadata`.
@@ -105,7 +105,7 @@ public struct ConsoleLogger: LogHandler {
     public var logLevel: Logger.Level
     
     /// The conosle that the messages will get logged to.
-    public let console: Console
+    public let console: Console & Sendable
 	
 	public var fragment: some LoggerFragment = defaultLoggerFragment()
 	
@@ -129,14 +129,14 @@ public struct ConsoleLogger: LogHandler {
     ///   - console: The console to log the messages to.
     ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
     ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    public init(label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
+    public init(label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
         self.label = label
         self.metadata = metadata
         self.logLevel = level
         self.console = console
     }
     
-    public init(label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+    public init(label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
         self.label = label
         self.metadata = metadata
         self.logLevel = level
@@ -193,7 +193,7 @@ extension LoggingSystem {
     ///   - console: The console the logger will log the messages to.
     ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
     ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    public static func bootstrap(console: Console, level: Logger.Level = .info, metadata: Logger.Metadata = [:]) {
+    public static func bootstrap(console: Console & Sendable, level: Logger.Level = .info, metadata: Logger.Metadata = [:]) {
         self.bootstrap { label in
             return ConsoleLogger(label: label, console: console, level: level, metadata: metadata)
         }

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -118,7 +118,7 @@ public struct ConsoleLogger: LogHandler, Sendable {
 		function: String,
 		line: UInt
 	) {
-		self.log(level: level, message: message, metadata: metadata, source: file.prefix(while: { $0 != "/"  }), file: file, function: function, line: line)
+		self.log(level: level, message: message, metadata: metadata, source: String(file.prefix(while: { $0 != "/"  })), file: file, function: function, line: line)
 	}
 #endif
 	

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -109,19 +109,6 @@ public struct ConsoleLogger: LogHandler, Sendable {
     
     public var fragment: some LoggerFragment = defaultLoggerFragment()
     
-#if CI // satisfy the easily-confused API breakage checker
-    public func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
-        self.log(level: level, message: message, metadata: metadata, source: String(file.prefix(while: { $0 != "/"  })), file: file, function: function, line: line)
-    }
-#endif
-    
     /// Creates a new `ConsoleLogger` instance.
     ///
     /// - Parameters:

--- a/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
+++ b/Sources/ConsoleKit/Utilities/ConsoleLogger.swift
@@ -2,97 +2,14 @@ import Logging
 
 /// A `LoggerFragment` which implements the default logger message format.
 public func defaultLoggerFragment() -> some LoggerFragment {
-	TimestampFragment().and(LabelFragment().separated(" ")).maxLevel(.trace)
-		.and(LevelFragment().separated(" ").and(MessageFragment().separated(" ")))
-		.and(MetadataFragment().separated(" "))
-		.and(SourceLocationFragment().separated(" ").maxLevel(.debug))
+    TimestampFragment().and(LabelFragment().separated(" ")).maxLevel(.trace)
+        .and(LevelFragment().separated(" ").and(MessageFragment().separated(" ")))
+        .and(MetadataFragment().separated(" "))
+        .and(SourceLocationFragment().separated(" ").maxLevel(.debug))
 }
 
 /// Outputs logs to a `Console` via a `LoggerFragment` pipeline.
 public struct ConsoleFragmentLogger<T: LoggerFragment>: LogHandler, Sendable {
-	public let label: String
-	
-	/// See `LogHandler.metadata`.
-	public var metadata: Logger.Metadata
-	
-	/// See `LogHandler.metadataProvider`.
-	public var metadataProvider: Logger.MetadataProvider?
-	
-	/// See `LogHandler.logLevel`.
-	public var logLevel: Logger.Level
-	
-	/// The conosle that the messages will get logged to.
-	public let console: Console & Sendable
-	
-	/// The `LoggerFragment` this logger outputs through.
-	public var fragment: T
-	
-	/// Creates a new `ConsoleLogger` instance.
-	///
-	/// - Parameters:
-	///   - fragment: The `LoggerFragment` this logger outputs through.
-	///   - label: Unique identifier for this logger.
-	///   - console: The console to log the messages to.
-	///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
-	///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-	public init(fragment: T, label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
-		self.fragment = fragment
-		self.label = label
-		self.metadata = metadata
-		self.logLevel = level
-		self.console = console
-	}
-	
-	public init(fragment: T, label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
-		self.fragment = fragment
-		self.label = label
-		self.metadata = metadata
-		self.logLevel = level
-		self.console = console
-		self.metadataProvider = metadataProvider
-	}
-	
-	/// See `LogHandler[metadataKey:]`.
-	///
-	/// This just acts as a getter/setter for the `.metadata` property.
-	public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
-		get { return self.metadata[key] }
-		set { self.metadata[key] = newValue }
-	}
-	
-	/// See `LogHandler.log(level:message:metadata:source:file:function:line:)`.
-	public func log(
-		level: Logger.Level,
-		message: Logger.Message,
-		metadata: Logger.Metadata?,
-		source: String,
-		file: String,
-		function: String,
-		line: UInt
-	) {
-		var output = FragmentOutput()
-		var record = LogRecord(
-			level: level,
-			message: message,
-			metadata: metadata,
-			source: source,
-			file: file,
-			function: function,
-			line: line,
-			label: self.label,
-			loggerLevel: self.logLevel,
-			loggerMetadata: self.metadata,
-			metadataProvider: self.metadataProvider
-		)
-		
-		self.fragment.write(&record, to: &output)
-
-		self.console.output(output.text)
-	}
-}
-
-/// Outputs logs to a `Console`.
-public struct ConsoleLogger: LogHandler, Sendable {
     public let label: String
     
     /// See `LogHandler.metadata`.
@@ -105,38 +22,29 @@ public struct ConsoleLogger: LogHandler, Sendable {
     public var logLevel: Logger.Level
     
     /// The conosle that the messages will get logged to.
-    public let console: Console & Sendable
-	
-	public var fragment: some LoggerFragment = defaultLoggerFragment()
-	
-#if CI // satisfy the easily-confused API breakage checker
-	public func log(
-		level: Logger.Level,
-		message: Logger.Message,
-		metadata: Logger.Metadata?,
-		file: String,
-		function: String,
-		line: UInt
-	) {
-		self.log(level: level, message: message, metadata: metadata, source: String(file.prefix(while: { $0 != "/"  })), file: file, function: function, line: line)
-	}
-#endif
-	
+    public let console: Console
+    
+    /// The `LoggerFragment` this logger outputs through.
+    public var fragment: T
+    
     /// Creates a new `ConsoleLogger` instance.
     ///
     /// - Parameters:
+    ///   - fragment: The `LoggerFragment` this logger outputs through.
     ///   - label: Unique identifier for this logger.
     ///   - console: The console to log the messages to.
     ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
     ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    public init(label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
+    public init(fragment: T, label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
+        self.fragment = fragment
         self.label = label
         self.metadata = metadata
         self.logLevel = level
         self.console = console
     }
     
-    public init(label: String, console: Console & Sendable, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+    public init(fragment: T, label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+        self.fragment = fragment
         self.label = label
         self.metadata = metadata
         self.logLevel = level
@@ -157,30 +65,122 @@ public struct ConsoleLogger: LogHandler, Sendable {
         level: Logger.Level,
         message: Logger.Message,
         metadata: Logger.Metadata?,
-		source: String,
+        source: String,
         file: String,
         function: String,
         line: UInt
     ) {
         var output = FragmentOutput()
+        var record = LogRecord(
+            level: level,
+            message: message,
+            metadata: metadata,
+            source: source,
+            file: file,
+            function: function,
+            line: line,
+            label: self.label,
+            loggerLevel: self.logLevel,
+            loggerMetadata: self.metadata,
+            metadataProvider: self.metadataProvider
+        )
+        
+        self.fragment.write(&record, to: &output)
+        
+        self.console.output(output.text)
+    }
+}
 
-		var record = LogRecord(
-			level: level,
-			message: message,
-			metadata: metadata,
-			source: source,
-			file: file,
-			function: function,
-			line: line,
-			label: self.label,
-			loggerLevel: self.logLevel,
-			loggerMetadata: self.metadata,
-			metadataProvider: self.metadataProvider
-		)
-		
-		self.fragment.write(&record, to: &output)
-
-		self.console.output(output.text)
+/// Outputs logs to a `Console`.
+public struct ConsoleLogger: LogHandler, Sendable {
+    public let label: String
+    
+    /// See `LogHandler.metadata`.
+    public var metadata: Logger.Metadata
+    
+    /// See `LogHandler.metadataProvider`.
+    public var metadataProvider: Logger.MetadataProvider?
+    
+    /// See `LogHandler.logLevel`.
+    public var logLevel: Logger.Level
+    
+    /// The conosle that the messages will get logged to.
+    public let console: Console
+    
+    public var fragment: some LoggerFragment = defaultLoggerFragment()
+    
+#if CI // satisfy the easily-confused API breakage checker
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        self.log(level: level, message: message, metadata: metadata, source: String(file.prefix(while: { $0 != "/"  })), file: file, function: function, line: line)
+    }
+#endif
+    
+    /// Creates a new `ConsoleLogger` instance.
+    ///
+    /// - Parameters:
+    ///   - label: Unique identifier for this logger.
+    ///   - console: The console to log the messages to.
+    ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
+    ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
+    public init(label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:]) {
+        self.label = label
+        self.metadata = metadata
+        self.logLevel = level
+        self.console = console
+    }
+    
+    public init(label: String, console: Console, level: Logger.Level = .debug, metadata: Logger.Metadata = [:], metadataProvider: Logger.MetadataProvider?) {
+        self.label = label
+        self.metadata = metadata
+        self.logLevel = level
+        self.console = console
+        self.metadataProvider = metadataProvider
+    }
+    
+    /// See `LogHandler[metadataKey:]`.
+    ///
+    /// This just acts as a getter/setter for the `.metadata` property.
+    public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { return self.metadata[key] }
+        set { self.metadata[key] = newValue }
+    }
+    
+    /// See `LogHandler.log(level:message:metadata:source:file:function:line:)`.
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        var output = FragmentOutput()
+        
+        var record = LogRecord(
+            level: level,
+            message: message,
+            metadata: metadata,
+            source: source,
+            file: file,
+            function: function,
+            line: line,
+            label: self.label,
+            loggerLevel: self.logLevel,
+            loggerMetadata: self.metadata,
+            metadataProvider: self.metadataProvider
+        )
+        
+        self.fragment.write(&record, to: &output)
+        
+        self.console.output(output.text)
     }
 }
 
@@ -193,7 +193,7 @@ extension LoggingSystem {
     ///   - console: The console the logger will log the messages to.
     ///   - level: The minimum level of message that the logger will output. This defaults to `.debug`, the lowest level.
     ///   - metadata: Extra metadata to log with the message. This defaults to an empty dictionary.
-    public static func bootstrap(console: Console & Sendable, level: Logger.Level = .info, metadata: Logger.Metadata = [:]) {
+    public static func bootstrap(console: Console, level: Logger.Level = .info, metadata: Logger.Metadata = [:]) {
         self.bootstrap { label in
             return ConsoleLogger(label: label, console: console, level: level, metadata: metadata)
         }

--- a/Sources/ConsoleKit/Utilities/GenerateAsyncAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAsyncAutocompleteCommand.swift
@@ -3,9 +3,9 @@ import Foundation
 struct GenerateAsyncAutocompleteCommand: AsyncCommand {
     var help: String { "Generate shell completion scripts for the executable" }
 
-    var rootCommand: AnyAsyncCommand?
+    var rootCommand: (any AnyAsyncCommand)?
 
-    init(rootCommand: AnyAsyncCommand? = nil) {
+    init(rootCommand: (any AnyAsyncCommand)? = nil) {
         self.rootCommand = rootCommand
     }
 

--- a/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
+++ b/Sources/ConsoleKit/Utilities/GenerateAutocompleteCommand.swift
@@ -3,9 +3,9 @@ import Foundation
 struct GenerateAutocompleteCommand: Command {
     var help: String { "Generate shell completion scripts for the executable" }
 
-    var rootCommand: AnyCommand?
+    var rootCommand: (any AnyCommand)?
 
-    init(rootCommand: AnyCommand? = nil) {
+    init(rootCommand: (any AnyCommand)? = nil) {
         self.rootCommand = rootCommand
     }
 

--- a/Sources/ConsoleKit/Utilities/LoggerFragment.swift
+++ b/Sources/ConsoleKit/Utilities/LoggerFragment.swift
@@ -1,0 +1,281 @@
+import Logging
+
+/// Information about a specific log message, including information from the logger the message was logged to.
+public struct LogRecord {
+	/// The log level of the message
+	public var level: Logger.Level
+	/// The logged message
+	public var message: Logger.Message
+	/// The metadata explicitly associated with the logged message
+	public var metadata: Logger.Metadata?
+	/// The source of the log message, usually the module name
+	public var source: String
+	/// The file the message was logged from
+	public var file: String
+	/// The function the message was logged from
+	public var function: String
+	/// The line number in the file the message was logged from
+	public var line: UInt
+	
+	
+	/// The label of the logger the message was logged to
+	public var label: String
+	/// The log level of the logger the message was logged to
+	public var loggerLevel: Logger.Level
+	/// The metadata associated with the logger the message was logged to
+	public var loggerMetadata: Logger.Metadata
+	/// The metadata provider associated with the logger the message was logged to
+	public var metadataProvider: Logger.MetadataProvider?
+	
+	/// The resolved metadata, combining all of the sources. This is computed lazily.
+	var _allMetadata: [String: Logger.MetadataValue]? = nil
+	
+	/// splits a path on the /Sources/ folder, returning everything after
+	///
+	///     "/Users/developer/dev/MyApp/Sources/Run/main.swift"
+	///     // becomes
+	///     "Run/main.swift"
+	///
+	public var conciseSourcePath: String {
+		ConsoleKit.conciseSourcePath(self.file)
+	}
+	
+	/// Combine all of the metadata into a single set. The result is cached after it is computed once.
+	public mutating func allMetadata() -> [String: Logger.MetadataValue] {
+		if let all = self._allMetadata {
+			return all
+		} else {
+			let meta = (self.metadata ?? [:])
+				.merging(self.loggerMetadata, uniquingKeysWith: { (a, _) in a })
+				.merging(self.metadataProvider?.get() ?? [:], uniquingKeysWith: { (a, _) in a })
+			self._allMetadata = meta
+			return meta
+		}
+	}
+}
+
+/// The output of a `LoggerFragment`, including some intermediary state used for things like deduplicating separators.
+public struct FragmentOutput {
+	public var text = ConsoleText()
+	public var needsSeparator = false
+	
+	public init() { }
+
+	public static func +=(lhs: inout FragmentOutput, rhs: ConsoleText) {
+		lhs.text = ConsoleText(fragments: lhs.text.fragments + rhs.fragments)
+	}
+}
+
+/// A fragment of a log message.
+public protocol LoggerFragment {
+	/// Indicates whether the fragment will write anything to `output` when `write` is called. This is used to determine whether writing a separator should be skipped.
+	func hasContent(record: inout LogRecord) -> Bool
+	
+	/// Add this fragment's output to the console text.
+	///
+	/// Fragments are allowed to mutate the `LogRecord` seen by later fragments in the pipeline, but this should generally be done before any fragments write text to avoid inconsistencies in the final message.
+	func write(_ record: inout LogRecord, to output: inout FragmentOutput)
+}
+
+extension LoggerFragment {
+	public func hasContent(record: inout LogRecord) -> Bool {
+		true
+	}
+}
+
+extension LoggerFragment {
+	/// Make the current fragment conditional, only calling its `output` method if the record's `loggerLevel` is `maxLevel` or lower
+	///
+	///	The sequence
+	/// ```
+	/// Literal("IsDebugOrTrace").maxLevel(.debug)
+	/// ```
+	///	will only include "IsDebugOrTrace" in the output when the log level is debug or lower.
+	func maxLevel(_ level: Logger.Level) -> IfMaxLevelFragment<Self> {
+		IfMaxLevelFragment(self, maxLevel: level)
+	}
+	
+	/// Combine the current fragment with another, which will be written after the current fragment finishes.
+	func and<T: LoggerFragment>(_ other: T) -> AndFragment<Self, T> {
+		AndFragment(self, other)
+	}
+	
+	/// Add a literal prefix to the current fragment.
+	func prefixed(_ text: ConsoleText) -> AndFragment<LiteralFragment, Self> {
+		AndFragment(LiteralFragment(text), self)
+	}
+	
+	/// Add a literal suffix to the current fragment.
+	func suffixed(_ text: ConsoleText) -> AndFragment<Self, LiteralFragment> {
+		AndFragment(self, LiteralFragment(text))
+	}
+	
+	/// Appends the given separator text to the output before `self`'s output, as long as a separator is needed.
+	///
+	/// If the wrapped fragment reports that it has no content, no separator will be inserted.
+	func separated(_ text: ConsoleText) -> SeparatorFragment<Self> {
+		SeparatorFragment(text, fragment: self)
+	}
+}
+
+/// Make the current fragment conditional, only calling its `output` method if the record's `loggerLevel` is `maxLevel` or lower
+///
+///	The sequence
+/// ```
+/// Literal("IsDebugOrTrace").maxLevel(.debug)
+/// ```
+///	will only include "IsDebugOrTrace" in the output when the log level is debug or lower.
+///
+///	This fragment is considered to not have content if the logging level is higher than than `maxLevel`.
+public struct IfMaxLevelFragment<T: LoggerFragment>: LoggerFragment {
+	public let maxLevel: Logger.Level
+	public let fragment: T
+	
+	public init(_ fragment: T, maxLevel: Logger.Level) {
+		self.fragment = fragment
+		self.maxLevel = maxLevel
+	}
+	
+	func shouldWrite(_ record: LogRecord) -> Bool {
+		record.loggerLevel <= self.maxLevel
+	}
+	
+	public func hasContent(record: inout LogRecord) -> Bool {
+		if self.shouldWrite(record) {
+			return self.fragment.hasContent(record: &record)
+		} else {
+			return false
+		}
+	}
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		if self.shouldWrite(record) {
+			self.fragment.write(&record, to: &output)
+		}
+	}
+}
+
+/// Combine the current fragment with another, which will be written after the current fragment finishes.
+public struct AndFragment<T: LoggerFragment, U: LoggerFragment>: LoggerFragment {
+	public let first: T
+	public let second: U
+	
+	public init(_ first: T, _ second: U) {
+		self.first = first
+		self.second = second
+	}
+	
+	public func hasContent(record: inout LogRecord) -> Bool {
+		self.first.hasContent(record: &record) || self.second.hasContent(record: &record)
+	}
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		self.first.write(&record, to: &output)
+		self.second.write(&record, to: &output)
+	}
+}
+
+/// Writes the label of the logger, and requests a separator for the next fragment.
+public struct LabelFragment: LoggerFragment {
+	public init() { }
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		output += "[ \(record.label) ]".consoleText()
+		output.needsSeparator = true
+	}
+}
+
+/// Writes the level of the logged message, and requests a separator for the next fragment.
+public struct LevelFragment: LoggerFragment {
+	public init() { }
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		output += "[ \(record.level.name) ]".consoleText(record.level.style)
+		output.needsSeparator = true
+	}
+}
+
+/// Writes the given text to the output. This type does not request a separator for the next fragment
+public struct LiteralFragment: LoggerFragment {
+	public let literal: ConsoleText
+	
+	public init(_ literal: ConsoleText) {
+		self.literal = literal
+	}
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		output += self.literal
+	}
+}
+
+public struct SeparatorFragment<T: LoggerFragment>: LoggerFragment {
+	public let literal: ConsoleText
+	public var fragment: T
+	
+	public init(_ literal: ConsoleText, fragment: T) {
+		self.literal = literal
+		self.fragment = fragment
+	}
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		if output.needsSeparator {
+			if self.fragment.hasContent(record: &record) {
+				output.needsSeparator = false
+				output += self.literal
+			}
+		}
+		
+		self.fragment.write(&record, to: &output)
+	}
+}
+
+/// Writes the logged message to the output, and requests a separator for the next fragment.
+public struct MessageFragment: LoggerFragment {
+	public init() { }
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		output += record.message.description.consoleText()
+		output.needsSeparator = true
+	}
+}
+
+/// Writes the combined metadata to the output, and requests a separator for the next fragment only if the metadata was not empty.
+///
+/// This fragment is considered to not have content if the metadata is empty.
+public struct MetadataFragment: LoggerFragment {
+	public init() { }
+	
+	public func hasContent(record: inout LogRecord) -> Bool {
+		 !record.allMetadata().isEmpty
+	}
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		let allMetadata = record.allMetadata()
+		
+		guard !allMetadata.isEmpty else { return }
+		
+		output += allMetadata.sortedDescriptionWithoutQuotes.consoleText()
+		output.needsSeparator = true
+	}
+}
+
+/// Writes the file location of the logged message, including the line. This fragment requests a separator for the next fragment.
+public struct FileFragment: LoggerFragment {
+	public init() { }
+	
+	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+		let file = record.conciseSourcePath + ":" + record.line.description
+		output += "(" + file.consoleText() + ")"
+		output.needsSeparator = true
+	}
+}
+
+private extension Logger.Metadata {
+	var sortedDescriptionWithoutQuotes: String {
+		let contents = Array(self)
+			.sorted(by: { $0.0 < $1.0 })
+			.map { "\($0.description): \($1)" }
+			.joined(separator: ", ")
+		return "[\(contents)]"
+	}
+}

--- a/Sources/ConsoleKit/Utilities/LoggerFragment.swift
+++ b/Sources/ConsoleKit/Utilities/LoggerFragment.swift
@@ -30,16 +30,6 @@ public struct LogRecord {
 	/// The resolved metadata, combining all of the sources. This is computed lazily.
 	var _allMetadata: [String: Logger.MetadataValue]? = nil
 	
-	/// splits a path on the /Sources/ folder, returning everything after
-	///
-	///     "/Users/developer/dev/MyApp/Sources/Run/main.swift"
-	///     // becomes
-	///     "Run/main.swift"
-	///
-	public var conciseSourcePath: String {
-		ConsoleKit.conciseSourcePath(self.file)
-	}
-	
 	/// Combine all of the metadata into a single set. The result is cached after it is computed once.
 	public mutating func allMetadata() -> [String: Logger.MetadataValue] {
 		if let all = self._allMetadata {
@@ -264,7 +254,7 @@ public struct FileFragment: LoggerFragment {
 	public init() { }
 	
 	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		let file = record.conciseSourcePath + ":" + record.line.description
+		let file = record.file + ":" + record.line.description
 		output += "(" + file.consoleText() + ")"
 		output.needsSeparator = true
 	}

--- a/Sources/ConsoleKit/Utilities/LoggerFragment.swift
+++ b/Sources/ConsoleKit/Utilities/LoggerFragment.swift
@@ -14,294 +14,294 @@ import WASILibc
 
 /// Information about a specific log message, including information from the logger the message was logged to.
 public struct LogRecord {
-	/// The log level of the message
-	public var level: Logger.Level
-	/// The logged message
-	public var message: Logger.Message
-	/// The metadata explicitly associated with the logged message
-	public var metadata: Logger.Metadata?
-	/// The source of the log message, usually the module name
-	public var source: String
-	/// The file the message was logged from
-	public var file: String
-	/// The function the message was logged from
-	public var function: String
-	/// The line number in the file the message was logged from
-	public var line: UInt
-	
-	
-	/// The label of the logger the message was logged to
-	public var label: String
-	/// The log level of the logger the message was logged to
-	public var loggerLevel: Logger.Level
-	/// The metadata associated with the logger the message was logged to
-	public var loggerMetadata: Logger.Metadata
-	/// The metadata provider associated with the logger the message was logged to
-	public var metadataProvider: Logger.MetadataProvider?
-	
-	/// Combine all of the metadata into a single set.
-	public mutating func allMetadata() -> [String: Logger.MetadataValue] {
-		// We aren't mutating self here currently, but keeping the method marked that way will ensure we can cache the result without breaking the public API if we decide that's desirable.
-		(self.metadata ?? [:])
-			.merging(self.loggerMetadata, uniquingKeysWith: { (a, _) in a })
-			.merging(self.metadataProvider?.get() ?? [:], uniquingKeysWith: { (a, _) in a })
-	}
+    /// The log level of the message
+    public var level: Logger.Level
+    /// The logged message
+    public var message: Logger.Message
+    /// The metadata explicitly associated with the logged message
+    public var metadata: Logger.Metadata?
+    /// The source of the log message, usually the module name
+    public var source: String
+    /// The file the message was logged from
+    public var file: String
+    /// The function the message was logged from
+    public var function: String
+    /// The line number in the file the message was logged from
+    public var line: UInt
+    
+    
+    /// The label of the logger the message was logged to
+    public var label: String
+    /// The log level of the logger the message was logged to
+    public var loggerLevel: Logger.Level
+    /// The metadata associated with the logger the message was logged to
+    public var loggerMetadata: Logger.Metadata
+    /// The metadata provider associated with the logger the message was logged to
+    public var metadataProvider: Logger.MetadataProvider?
+    
+    /// Combine all of the metadata into a single set.
+    public mutating func allMetadata() -> [String: Logger.MetadataValue] {
+        // We aren't mutating self here currently, but keeping the method marked that way will ensure we can cache the result without breaking the public API if we decide that's desirable.
+        (self.metadata ?? [:])
+            .merging(self.loggerMetadata, uniquingKeysWith: { (a, _) in a })
+            .merging(self.metadataProvider?.get() ?? [:], uniquingKeysWith: { (a, _) in a })
+    }
 }
 
 /// The output of a `LoggerFragment`, including some intermediary state used for things like deduplicating separators.
 public struct FragmentOutput {
-	public var text = ConsoleText()
-	public var needsSeparator = false
-	
-	public init() { }
-
-	public static func +=(lhs: inout FragmentOutput, rhs: ConsoleText) {
-		lhs.text = ConsoleText(fragments: lhs.text.fragments + rhs.fragments)
-	}
+    public var text = ConsoleText()
+    public var needsSeparator = false
+    
+    public init() { }
+    
+    public static func +=(lhs: inout FragmentOutput, rhs: ConsoleText) {
+        lhs.text = ConsoleText(fragments: lhs.text.fragments + rhs.fragments)
+    }
 }
 
 /// A fragment of a log message.
 public protocol LoggerFragment: Sendable {
-	/// Indicates whether the fragment will write anything to `output` when `write` is called. This is used to determine whether writing a separator should be skipped.
-	func hasContent(record: inout LogRecord) -> Bool
-	
-	/// Add this fragment's output to the console text.
-	///
-	/// Fragments are allowed to mutate the `LogRecord` seen by later fragments in the pipeline, but this should generally be done before any fragments write text to avoid inconsistencies in the final message.
-	func write(_ record: inout LogRecord, to output: inout FragmentOutput)
+    /// Indicates whether the fragment will write anything to `output` when `write` is called. This is used to determine whether writing a separator should be skipped.
+    func hasContent(record: inout LogRecord) -> Bool
+    
+    /// Add this fragment's output to the console text.
+    ///
+    /// Fragments are allowed to mutate the `LogRecord` seen by later fragments in the pipeline, but this should generally be done before any fragments write text to avoid inconsistencies in the final message.
+    func write(_ record: inout LogRecord, to output: inout FragmentOutput)
 }
 
 extension LoggerFragment {
-	public func hasContent(record: inout LogRecord) -> Bool {
-		// Most fragments have content unconditionally.
-		true
-	}
+    public func hasContent(record: inout LogRecord) -> Bool {
+        // Most fragments have content unconditionally.
+        true
+    }
 }
 
 extension LoggerFragment {
-	/// Make the current fragment conditional, only calling its `output` method if the record's `loggerLevel` is `maxLevel` or lower
-	///
-	///	The sequence
-	/// ```
-	/// Literal("IsDebugOrTrace").maxLevel(.debug)
-	/// ```
-	///	will only include "IsDebugOrTrace" in the output when the log level is debug or lower.
-	func maxLevel(_ level: Logger.Level) -> IfMaxLevelFragment<Self> {
-		IfMaxLevelFragment(self, maxLevel: level)
-	}
-	
-	/// Combine the current fragment with another, which will be written after the current fragment finishes.
-	func and<T: LoggerFragment>(_ other: T) -> AndFragment<Self, T> {
-		AndFragment(self, other)
-	}
-	
-	/// Add a literal prefix to the current fragment.
-	func prefixed(_ text: ConsoleText) -> AndFragment<LiteralFragment, Self> {
-		AndFragment(LiteralFragment(text), self)
-	}
-	
-	/// Add a literal suffix to the current fragment.
-	func suffixed(_ text: ConsoleText) -> AndFragment<Self, LiteralFragment> {
-		AndFragment(self, LiteralFragment(text))
-	}
-	
-	/// Appends the given separator text to the output before `self`'s output, as long as a separator is needed.
-	///
-	/// If the wrapped fragment reports that it has no content, no separator will be inserted.
-	func separated(_ text: ConsoleText) -> SeparatorFragment<Self> {
-		SeparatorFragment(text, fragment: self)
-	}
+    /// Make the current fragment conditional, only calling its `output` method if the record's `loggerLevel` is `maxLevel` or lower
+    ///
+    /// The sequence
+    /// ```
+    /// Literal("IsDebugOrTrace").maxLevel(.debug)
+    /// ```
+    /// will only include "IsDebugOrTrace" in the output when the log level is debug or lower.
+    func maxLevel(_ level: Logger.Level) -> IfMaxLevelFragment<Self> {
+        IfMaxLevelFragment(self, maxLevel: level)
+    }
+    
+    /// Combine the current fragment with another, which will be written after the current fragment finishes.
+    func and<T: LoggerFragment>(_ other: T) -> AndFragment<Self, T> {
+        AndFragment(self, other)
+    }
+    
+    /// Add a literal prefix to the current fragment.
+    func prefixed(_ text: ConsoleText) -> AndFragment<LiteralFragment, Self> {
+        AndFragment(LiteralFragment(text), self)
+    }
+    
+    /// Add a literal suffix to the current fragment.
+    func suffixed(_ text: ConsoleText) -> AndFragment<Self, LiteralFragment> {
+        AndFragment(self, LiteralFragment(text))
+    }
+    
+    /// Appends the given separator text to the output before `self`'s output, as long as a separator is needed.
+    ///
+    /// If the wrapped fragment reports that it has no content, no separator will be inserted.
+    func separated(_ text: ConsoleText) -> SeparatorFragment<Self> {
+        SeparatorFragment(text, fragment: self)
+    }
 }
 
 /// Make the current fragment conditional, only calling its `output` method if the record's `loggerLevel` is `maxLevel` or lower
 ///
-///	The sequence
+/// The sequence
 /// ```
 /// Literal("IsDebugOrTrace").maxLevel(.debug)
 /// ```
-///	will only include "IsDebugOrTrace" in the output when the log level is debug or lower.
+/// will only include "IsDebugOrTrace" in the output when the log level is debug or lower.
 ///
-///	This fragment is considered to not have content if the logging level is higher than than `maxLevel`.
+/// This fragment is considered to not have content if the logging level is higher than than `maxLevel`.
 public struct IfMaxLevelFragment<T: LoggerFragment>: LoggerFragment {
-	public let maxLevel: Logger.Level
-	public let fragment: T
-	
-	public init(_ fragment: T, maxLevel: Logger.Level) {
-		self.fragment = fragment
-		self.maxLevel = maxLevel
-	}
-	
-	func shouldWrite(_ record: LogRecord) -> Bool {
-		record.loggerLevel <= self.maxLevel
-	}
-	
-	public func hasContent(record: inout LogRecord) -> Bool {
-		if self.shouldWrite(record) {
-			return self.fragment.hasContent(record: &record)
-		} else {
-			return false
-		}
-	}
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		if self.shouldWrite(record) {
-			self.fragment.write(&record, to: &output)
-		}
-	}
+    public let maxLevel: Logger.Level
+    public let fragment: T
+    
+    public init(_ fragment: T, maxLevel: Logger.Level) {
+        self.fragment = fragment
+        self.maxLevel = maxLevel
+    }
+    
+    func shouldWrite(_ record: LogRecord) -> Bool {
+        record.loggerLevel <= self.maxLevel
+    }
+    
+    public func hasContent(record: inout LogRecord) -> Bool {
+        if self.shouldWrite(record) {
+            return self.fragment.hasContent(record: &record)
+        } else {
+            return false
+        }
+    }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        if self.shouldWrite(record) {
+            self.fragment.write(&record, to: &output)
+        }
+    }
 }
 
 /// Combine the current fragment with another, which will be written after the current fragment finishes.
 public struct AndFragment<T: LoggerFragment, U: LoggerFragment>: LoggerFragment {
-	public let first: T
-	public let second: U
-	
-	public init(_ first: T, _ second: U) {
-		self.first = first
-		self.second = second
-	}
-	
-	public func hasContent(record: inout LogRecord) -> Bool {
-		self.first.hasContent(record: &record) || self.second.hasContent(record: &record)
-	}
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		self.first.write(&record, to: &output)
-		self.second.write(&record, to: &output)
-	}
+    public let first: T
+    public let second: U
+    
+    public init(_ first: T, _ second: U) {
+        self.first = first
+        self.second = second
+    }
+    
+    public func hasContent(record: inout LogRecord) -> Bool {
+        self.first.hasContent(record: &record) || self.second.hasContent(record: &record)
+    }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        self.first.write(&record, to: &output)
+        self.second.write(&record, to: &output)
+    }
 }
 
 /// Writes the label of the logger, and requests a separator for the next fragment.
 public struct LabelFragment: LoggerFragment {
-	public init() { }
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		output += "[ \(record.label) ]".consoleText()
-		output.needsSeparator = true
-	}
+    public init() { }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        output += "[ \(record.label) ]".consoleText()
+        output.needsSeparator = true
+    }
 }
 
 /// Writes the level of the logged message, and requests a separator for the next fragment.
 public struct LevelFragment: LoggerFragment {
-	public init() { }
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		output += "[ \(record.level.name) ]".consoleText(record.level.style)
-		output.needsSeparator = true
-	}
+    public init() { }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        output += "[ \(record.level.name) ]".consoleText(record.level.style)
+        output.needsSeparator = true
+    }
 }
 
 /// Writes the given text to the output. This type does not request a separator for the next fragment
 public struct LiteralFragment: LoggerFragment {
-	public let literal: ConsoleText
-	
-	public init(_ literal: ConsoleText) {
-		self.literal = literal
-	}
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		output += self.literal
-	}
+    public let literal: ConsoleText
+    
+    public init(_ literal: ConsoleText) {
+        self.literal = literal
+    }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        output += self.literal
+    }
 }
 
 public struct SeparatorFragment<T: LoggerFragment>: LoggerFragment {
-	public let literal: ConsoleText
-	public var fragment: T
-	
-	public init(_ literal: ConsoleText, fragment: T) {
-		self.literal = literal
-		self.fragment = fragment
-	}
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		if output.needsSeparator {
-			if self.fragment.hasContent(record: &record) {
-				output.needsSeparator = false
-				output += self.literal
-			}
-		}
-		
-		self.fragment.write(&record, to: &output)
-	}
+    public let literal: ConsoleText
+    public var fragment: T
+    
+    public init(_ literal: ConsoleText, fragment: T) {
+        self.literal = literal
+        self.fragment = fragment
+    }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        if output.needsSeparator {
+            if self.fragment.hasContent(record: &record) {
+                output.needsSeparator = false
+                output += self.literal
+            }
+        }
+        
+        self.fragment.write(&record, to: &output)
+    }
 }
 
 /// Writes the logged message to the output, and requests a separator for the next fragment.
 public struct MessageFragment: LoggerFragment {
-	public init() { }
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		output += record.message.description.consoleText()
-		output.needsSeparator = true
-	}
+    public init() { }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        output += record.message.description.consoleText()
+        output.needsSeparator = true
+    }
 }
 
 /// Writes the combined metadata to the output, and requests a separator for the next fragment only if the metadata was not empty.
 ///
 /// This fragment is considered to not have content if the metadata is empty.
 public struct MetadataFragment: LoggerFragment {
-	public init() { }
-	
-	public func hasContent(record: inout LogRecord) -> Bool {
-		 !record.allMetadata().isEmpty
-	}
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		let allMetadata = record.allMetadata()
-		
-		guard !allMetadata.isEmpty else { return }
-		
-		output += allMetadata.sortedDescriptionWithoutQuotes.consoleText()
-		output.needsSeparator = true
-	}
+    public init() { }
+    
+    public func hasContent(record: inout LogRecord) -> Bool {
+        !record.allMetadata().isEmpty
+    }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        let allMetadata = record.allMetadata()
+        
+        guard !allMetadata.isEmpty else { return }
+        
+        output += allMetadata.sortedDescriptionWithoutQuotes.consoleText()
+        output.needsSeparator = true
+    }
 }
 
 /// Writes the file location of the logged message, including the line. This fragment requests a separator for the next fragment.
 public struct SourceLocationFragment: LoggerFragment {
-	public init() { }
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		let file = record.file + ":" + record.line.description
-		output += "(" + file.consoleText() + ")"
-		output.needsSeparator = true
-	}
+    public init() { }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        let file = record.file + ":" + record.line.description
+        output += "(" + file.consoleText() + ")"
+        output.needsSeparator = true
+    }
 }
 
 public struct TimestampFragment: LoggerFragment {
-	public init() { }
-	
-	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-       output += self.timestamp().consoleText()
-		output.needsSeparator = true
-	}
-	
-	private func timestamp() -> String {
-		var buffer = [Int8](repeating: 0, count: 255)
-		#if os(Windows)
-		var timestamp = __time64_t()
-		_ = _time64(&timestamp)
-
-		var localTime = tm()
-		_ = _localtime64_s(&localTime, &timestamp)
-
-		_ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
-		#else
-		var timestamp = time(nil)
-		let localTime = localtime(&timestamp)
-		strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
-		#endif
-		return buffer.withUnsafeBufferPointer {
-			$0.withMemoryRebound(to: CChar.self) {
-				String(cString: $0.baseAddress!)
-			}
-		}
-	}
+    public init() { }
+    
+    public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
+        output += self.timestamp().consoleText()
+        output.needsSeparator = true
+    }
+    
+    private func timestamp() -> String {
+        var buffer = [Int8](repeating: 0, count: 255)
+#if os(Windows)
+        var timestamp = __time64_t()
+        _ = _time64(&timestamp)
+        
+        var localTime = tm()
+        _ = _localtime64_s(&localTime, &timestamp)
+        
+        _ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
+#else
+        var timestamp = time(nil)
+        let localTime = localtime(&timestamp)
+        strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
+#endif
+        return buffer.withUnsafeBufferPointer {
+            $0.withMemoryRebound(to: CChar.self) {
+                String(cString: $0.baseAddress!)
+            }
+        }
+    }
 }
 
 private extension Logger.Metadata {
-	var sortedDescriptionWithoutQuotes: String {
-		let contents = Array(self)
-			.sorted(by: { $0.0 < $1.0 })
-			.map { "\($0.description): \($1)" }
-			.joined(separator: ", ")
-		return "[\(contents)]"
-	}
+    var sortedDescriptionWithoutQuotes: String {
+        let contents = Array(self)
+            .sorted(by: { $0.0 < $1.0 })
+            .map { "\($0.description): \($1)" }
+            .joined(separator: ", ")
+        return "[\(contents)]"
+    }
 }

--- a/Sources/ConsoleKit/Utilities/LoggerFragment.swift
+++ b/Sources/ConsoleKit/Utilities/LoggerFragment.swift
@@ -269,30 +269,8 @@ public struct TimestampFragment: LoggerFragment {
 	public init() { }
 	
 	public func write(_ record: inout LogRecord, to output: inout FragmentOutput) {
-		if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-			output += self.timestampUninit().consoleText()
-		} else {
-			output += self.timestamp().consoleText()
-		}
-		
+       output += self.timestamp().consoleText()
 		output.needsSeparator = true
-	}
-	
-	@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
-	private func timestampUninit() -> String {
-		String(unsafeUninitializedCapacity: 255) {
-			#if canImport(CRT)
-				var timestamp = __time64_t()
-				var localTime = tm()
-				_ = _time64(&timestamp)
-				_ = _localtime64_s(&localTime, &timestamp)
-			#else
-				var timestamp = time(nil)
-				var localTime = tm()
-				localtime_r(&timestamp, &localTime)
-			#endif
-			return $0.withMemoryRebound(to: Int8.self) { strftime($0.baseAddress!, $0.count, "%Y-%m-%dT%H:%M:%S%z", &localTime) }
-		}
 	}
 	
 	private func timestamp() -> String {

--- a/Sources/ConsoleKit/Utilities/LoggerFragment.swift
+++ b/Sources/ConsoleKit/Utilities/LoggerFragment.swift
@@ -78,7 +78,7 @@ extension LoggerFragment {
     }
 }
 
-extension LoggerFragment {
+public extension LoggerFragment {
     /// Make the current fragment conditional, only calling its `output` method if the record's `loggerLevel` is `maxLevel` or lower
     ///
     /// The sequence

--- a/Sources/ConsoleKitExample/main.swift
+++ b/Sources/ConsoleKitExample/main.swift
@@ -1,5 +1,6 @@
 import ConsoleKit
 import Foundation
+import Logging
 
 let console: Console = Terminal()
 var input = CommandInput(arguments: CommandLine.arguments)
@@ -8,6 +9,8 @@ var context = CommandContext(console: console, input: input)
 var commands = Commands(enableAutocomplete: true)
 commands.use(DemoCommand(), as: "demo", isDefault: false)
 
+LoggingSystem.bootstrap(console: Terminal(), level: .info)
+Logger(label: "one").info("One")
 do {
     let group = commands
         .group(help: "An example command-line application built with ConsoleKit")

--- a/Sources/ConsoleKitExample/main.swift
+++ b/Sources/ConsoleKitExample/main.swift
@@ -9,8 +9,6 @@ var context = CommandContext(console: console, input: input)
 var commands = Commands(enableAutocomplete: true)
 commands.use(DemoCommand(), as: "demo", isDefault: false)
 
-LoggingSystem.bootstrap(console: Terminal(), level: .info)
-Logger(label: "one").info("One")
 do {
     let group = commands
         .group(help: "An example command-line application built with ConsoleKit")

--- a/Sources/ConsoleLoggerExample/entrypoint.swift
+++ b/Sources/ConsoleLoggerExample/entrypoint.swift
@@ -1,0 +1,16 @@
+import Foundation
+import ConsoleKit
+import Logging
+
+@main
+struct ConsoleLoggerExample {
+    static func main() {
+        LoggingSystem.bootstrap(
+            fragment: timestampDefaultLoggerFragment(),
+            console: Terminal()
+        )
+        
+        // Prints "2023-08-21T00:00:00Z [ INFO ] Logged!"
+        Logger(label: "EXAMPLE").info("Logged!")
+    }
+}

--- a/Tests/AsyncConsoleKitTests/AsyncCommandTests.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncCommandTests.swift
@@ -136,7 +136,7 @@ final class AsyncCommandTests: XCTestCase {
             }
 
             var help: String = ""
-            var assertion: (Signature) -> ()
+            var assertion: @Sendable (Signature) -> ()
 
             func run(using context: CommandContext, signature: OptionInitialized.Signature) async throws {
                 assertion(signature)

--- a/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
@@ -87,7 +87,7 @@ final class StrictCommand: AsyncCommand {
         
         init() { }
     }
-	
+    
     let help: String = "I error if you pass in bad values"
 
     func run(using context: CommandContext, signature: Signature) async throws {

--- a/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
@@ -87,7 +87,8 @@ final class StrictCommand: AsyncCommand {
         
         init() { }
     }
-    var help: String = "I error if you pass in bad values"
+	
+    let help: String = "I error if you pass in bad values"
 
     func run(using context: CommandContext, signature: Signature) async throws {
         print("Done!")
@@ -97,7 +98,7 @@ final class StrictCommand: AsyncCommand {
 final class TestConsole: Console {
     var testInputQueue: [String]
     var testOutputQueue: [String]
-    var userInfo: [AnyHashable : Any]
+    var userInfo: [AnyHashable : Sendable]
 
     init() {
         self.testInputQueue = []

--- a/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
+++ b/Tests/AsyncConsoleKitTests/AsyncUtilities.swift
@@ -1,5 +1,6 @@
 import ConsoleKit
 import XCTest
+import NIOConcurrencyHelpers
 
 extension String: Error {}
 
@@ -96,12 +97,38 @@ final class StrictCommand: AsyncCommand {
 }
 
 final class TestConsole: Console {
-    var testInputQueue: [String]
-    var testOutputQueue: [String]
-    var userInfo: [AnyHashable : Sendable]
+    let _testInputQueue: NIOLockedValueBox<[String]> = NIOLockedValueBox([])
+    
+    var testInputQueue: [String] {
+        get {
+            self._testInputQueue.withLockedValue { $0 }
+        }
+        set {
+            self._testInputQueue.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    let _testOutputQueue: NIOLockedValueBox<[String]> = NIOLockedValueBox([])
+    var testOutputQueue: [String] {
+        get {
+            self._testOutputQueue.withLockedValue { $0 }
+        }
+        set {
+            self._testOutputQueue.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    let _userInfo: NIOLockedValueBox<[AnySendableHashable: Sendable]> = NIOLockedValueBox([:])
+    var userInfo: [AnySendableHashable: Sendable] {
+        get {
+            self._userInfo.withLockedValue { $0 }
+        }
+        set {
+            self._userInfo.withLockedValue { $0 = newValue }
+        }
+    }
 
     init() {
-        self.testInputQueue = []
         self.testOutputQueue = []
         self.userInfo = [:]
     }

--- a/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
+++ b/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class TestConsole: Console {
     var lastOutput: String? = nil
-    var userInfo = [AnyHashable: any Sendable]()
+    var userInfo = [AnySendableHashable: any Sendable]()
     
     func input(isSecure: Bool) -> String {
         ""

--- a/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
+++ b/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
@@ -18,7 +18,7 @@ final class TestConsole: Console {
 	}
 
 	func output(_ text: ConsoleText, newLine: Bool) {
-		self.lastOutput = text.description + (newLine ? "\n" : "")
+		
 	}
 
 	func report(error: String, newLine: Bool) {
@@ -34,18 +34,25 @@ final class TestConsole: Console {
 
 class ConsoleLoggerPerformanceTests: XCTestCase {
 	func testLoggingPerformance() throws  {
-		// averages from logger-fragment branch on my machine 0.547 0.551
-		try performance(expected: 1.066) // average from main branch on my machine
+		try performance(expected: 0.489) // average from main branch on my machine
+		
+		let console = TestConsole()
+		LoggingSystem.bootstrap({ label, provider in
+			ConsoleLogger(label: label, console: console)
+		}, metadataProvider: .init({
+			["provided1": "from metadata provider", "provided2": "another metadata provider"]
+		}))
+		
 		self.measure {
-			let console = TestConsole()
-			var logger1 = Logger(label: "codes.vapor.console.1") { label in
-				ConsoleLogger(label: label, console: console)
-			}
+			var logger1 = Logger(label: "codes.vapor.console.1")
 			
 			for _ in 0..<100_000 {
 				logger1.logLevel = .trace
 				logger1[metadataKey: "value"] = "one"
-				logger1.info("Info")
+				logger1.info(
+					"Info",
+					metadata: ["from-log": "value", "also-from-log": "other"]
+				)
 			}
 		}
 	}

--- a/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
+++ b/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
@@ -1,0 +1,57 @@
+//
+//  ConsoleLoggerPerformanceTests.swift
+//  
+//
+//  Created by Cole Kurkowski on 8/19/23.
+//
+
+import ConsoleKit
+import Logging
+import XCTest
+
+final class TestConsole: Console {
+	var lastOutput: String? = nil
+	var userInfo = [AnyHashable: Any]()
+	
+	func input(isSecure: Bool) -> String {
+		""
+	}
+
+	func output(_ text: ConsoleText, newLine: Bool) {
+		self.lastOutput = text.description + (newLine ? "\n" : "")
+	}
+
+	func report(error: String, newLine: Bool) {
+		//
+	}
+
+	func clear(_ type: ConsoleClear) {
+		//
+	}
+
+	var size: (width: Int, height: Int) { return (0, 0) }
+}
+
+class ConsoleLoggerPerformanceTests: XCTestCase {
+	func testLoggingPerformance() throws  {
+		// averages from logger-fragment branch on my machine 0.547 0.551
+		try performance(expected: 1.066) // average from main branch on my machine
+		self.measure {
+			let console = TestConsole()
+			var logger1 = Logger(label: "codes.vapor.console.1") { label in
+				ConsoleLogger(label: label, console: console)
+			}
+			
+			for _ in 0..<100_000 {
+				logger1.logLevel = .trace
+				logger1[metadataKey: "value"] = "one"
+				logger1.info("Info")
+			}
+		}
+	}
+}
+
+func performance(expected seconds: Double, name: String = #function, file: StaticString = #filePath, line: UInt = #line) throws {
+	try XCTSkipUnless(!_isDebugAssertConfiguration(), "[PERFORMANCE] Skipping \(name) in debug build mode", file: file, line: line)
+	print("[PERFORMANCE] \(name) expected: \(seconds) seconds")
+}

--- a/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
+++ b/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class TestConsole: Console {
 	var lastOutput: String? = nil
-	var userInfo = [AnyHashable: Any]()
+	var userInfo = [AnyHashable: any Sendable]()
 	
 	func input(isSecure: Bool) -> String {
 		""

--- a/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
+++ b/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
@@ -10,55 +10,55 @@ import Logging
 import XCTest
 
 final class TestConsole: Console {
-	var lastOutput: String? = nil
-	var userInfo = [AnyHashable: any Sendable]()
-	
-	func input(isSecure: Bool) -> String {
-		""
-	}
+    var lastOutput: String? = nil
+    var userInfo = [AnyHashable: any Sendable]()
+    
+    func input(isSecure: Bool) -> String {
+        ""
+    }
 
-	func output(_ text: ConsoleText, newLine: Bool) {
-		
-	}
+    func output(_ text: ConsoleText, newLine: Bool) {
+        
+    }
 
-	func report(error: String, newLine: Bool) {
-		//
-	}
+    func report(error: String, newLine: Bool) {
+        //
+    }
 
-	func clear(_ type: ConsoleClear) {
-		//
-	}
+    func clear(_ type: ConsoleClear) {
+        //
+    }
 
-	var size: (width: Int, height: Int) { return (0, 0) }
+    var size: (width: Int, height: Int) { return (0, 0) }
 }
 
 class ConsoleLoggerPerformanceTests: XCTestCase {
-	func testLoggingPerformance() throws  {
-		try performance(expected: 0.489) // average from main branch on my machine
-		
-		let console = TestConsole()
-		LoggingSystem.bootstrap({ label, provider in
-			ConsoleLogger(label: label, console: console)
-		}, metadataProvider: .init({
-			["provided1": "from metadata provider", "provided2": "another metadata provider"]
-		}))
-		
-		self.measure {
-			var logger1 = Logger(label: "codes.vapor.console.1")
-			
-			for _ in 0..<100_000 {
-				logger1.logLevel = .trace
-				logger1[metadataKey: "value"] = "one"
-				logger1.info(
-					"Info",
-					metadata: ["from-log": "value", "also-from-log": "other"]
-				)
-			}
-		}
-	}
+    func testLoggingPerformance() throws  {
+        try performance(expected: 0.489) // average from main branch on my machine
+        
+        let console = TestConsole()
+        LoggingSystem.bootstrap({ label, provider in
+            ConsoleLogger(label: label, console: console)
+        }, metadataProvider: .init({
+            ["provided1": "from metadata provider", "provided2": "another metadata provider"]
+        }))
+        
+        self.measure {
+            var logger1 = Logger(label: "codes.vapor.console.1")
+            
+            for _ in 0..<100_000 {
+                logger1.logLevel = .trace
+                logger1[metadataKey: "value"] = "one"
+                logger1.info(
+                    "Info",
+                    metadata: ["from-log": "value", "also-from-log": "other"]
+                )
+            }
+        }
+    }
 }
 
 func performance(expected seconds: Double, name: String = #function, file: StaticString = #filePath, line: UInt = #line) throws {
-	try XCTSkipUnless(!_isDebugAssertConfiguration(), "[PERFORMANCE] Skipping \(name) in debug build mode", file: file, line: line)
-	print("[PERFORMANCE] \(name) expected: \(seconds) seconds")
+    try XCTSkipUnless(!_isDebugAssertConfiguration(), "[PERFORMANCE] Skipping \(name) in debug build mode", file: file, line: line)
+    print("[PERFORMANCE] \(name) expected: \(seconds) seconds")
 }

--- a/Tests/ConsoleKitTests/ActivityTests.swift
+++ b/Tests/ConsoleKitTests/ActivityTests.swift
@@ -1,0 +1,14 @@
+@testable import ConsoleKit
+import XCTest
+
+final class ActivityTests: XCTestCase {
+    func testActivityWidthKey() {
+        var dict = [AnyHashable: String]()
+        
+        dict[AnyHashable(ActivityBarWidthKey())] = "width key"
+        dict[AnyHashable("ConsoleKit.ActivityBarWidthKey")] = "string key"
+        
+        XCTAssertEqual(dict[AnyHashable(ActivityBarWidthKey())], "width key")
+        XCTAssertEqual(dict[AnyHashable("ConsoleKit.ActivityBarWidthKey")],  "string key")
+    }
+}

--- a/Tests/ConsoleKitTests/LoggingTests.swift
+++ b/Tests/ConsoleKitTests/LoggingTests.swift
@@ -84,16 +84,14 @@ final class ConsoleLoggerTests: XCTestCase {
         }
         let console = TestConsole()
         
-        LoggingSystem.bootstrap({ label, metadataProvider in
-            ConsoleLogger(label: label, console: console, metadataProvider: metadataProvider)
-        }, metadataProvider: simpleTraceIDMetadataProvider)
-        
-        let logger = Logger(label: "codes.vapor.console")
+        let logger = Logger(label: "codes.vapor.console") { label in
+            ConsoleLogger(label: label, console: console, metadataProvider: simpleTraceIDMetadataProvider)
+        }
 
         TraceNamespace.$simpleTraceID.withValue("1234-5678") {
             logger.debug("debug")
         }
-        XCTAssertLog(console, .debug, "debug [simple-trace-id: 1234-5678] (ConsoleKitTests/LoggingTests.swift:94)")
+        XCTAssertLog(console, .debug, "debug [simple-trace-id: 1234-5678] (ConsoleKitTests/LoggingTests.swift:92)")
     }
 }
 

--- a/Tests/ConsoleKitTests/TerminalTests.swift
+++ b/Tests/ConsoleKitTests/TerminalTests.swift
@@ -36,7 +36,7 @@ class TerminalTests: XCTestCase {
 
     func testStylizeRGBColor() throws {
         XCTAssertEqual(
-        	"TEST".terminalStylize(.init(color: .custom(r: 100, g: 100, b: 100))),
+            "TEST".terminalStylize(.init(color: .custom(r: 100, g: 100, b: 100))),
             "\u{001b}[0;38;2;100;100;100mTEST\u{001b}[0m"
         )
         XCTAssertEqual(

--- a/Tests/ConsoleKitTests/Utilities.swift
+++ b/Tests/ConsoleKitTests/Utilities.swift
@@ -1,5 +1,6 @@
 import ConsoleKit
 import XCTest
+import NIOConcurrencyHelpers
 
 extension String: Error {}
 
@@ -95,9 +96,36 @@ final class StrictCommand: Command {
 }
 
 final class TestConsole: Console {
-    var testInputQueue: [String]
-    var testOutputQueue: [String]
-    var userInfo: [AnyHashable : Sendable]
+    let _testInputQueue: NIOLockedValueBox<[String]> = NIOLockedValueBox([])
+    
+    var testInputQueue: [String] {
+        get {
+            self._testInputQueue.withLockedValue { $0 }
+        }
+        set {
+            self._testInputQueue.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    let _testOutputQueue: NIOLockedValueBox<[String]> = NIOLockedValueBox([])
+    var testOutputQueue: [String] {
+        get {
+            self._testOutputQueue.withLockedValue { $0 }
+        }
+        set {
+            self._testOutputQueue.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    let _userInfo: NIOLockedValueBox<[AnySendableHashable: Sendable]> = NIOLockedValueBox([:])
+    var userInfo: [AnySendableHashable: Sendable] {
+        get {
+            self._userInfo.withLockedValue { $0 }
+        }
+        set {
+            self._userInfo.withLockedValue { $0 = newValue }
+        }
+    }
 
     init() {
         self.testInputQueue = []

--- a/Tests/ConsoleKitTests/Utilities.swift
+++ b/Tests/ConsoleKitTests/Utilities.swift
@@ -97,7 +97,7 @@ final class StrictCommand: Command {
 final class TestConsole: Console {
     var testInputQueue: [String]
     var testOutputQueue: [String]
-    var userInfo: [AnyHashable : Any]
+    var userInfo: [AnyHashable : Sendable]
 
     init() {
         self.testInputQueue = []


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
This PR refactors `ConsoleLogger` to break out the functionality into smaller pieces. The goal of this is to allow end users to customize the log output without having to deal with writing a logger themselves. Things like adding a timestamp at the beginning of the log message can be accomplished without having to re-write any of the logic inside `ConsoleKit` by writing a custom `LoggerFragment`. Additionally, since the actual code for constructing the log message is so short, copying it to make modifications inside the message isn't as much of a commitment as copying the whole `ConsoleLogger` implementation is.

This change would at least partially address #140 by making it easier to customize when metadata, etc is logged.

This change also incorporated moving from the deprecated `Logging.LogHandler` protocol method to the newer one which includes the source parameter

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
