### PR TITLE
Make Commands Sendable

### DIFF
--- a/Sources/ConsoleKit/Command/AnyCommand.swift
+++ b/Sources/ConsoleKit/Command/AnyCommand.swift
@@ -1,5 +1,5 @@
 /// A type-erased `Command`.
-public protocol AnyCommand {
+public protocol AnyCommand: Sendable {
     /// Text that will be displayed when `--help` is passed.
     var help: String { get }
     

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -41,7 +41,7 @@ extension CommandSignature {
     }
 }
 
-enum InputValue<T> {
+enum InputValue<T: Sendable>: Sendable {
     case initialized(T)
     case uninitialized
 }

--- a/Sources/ConsoleKit/Command/CommandSignature.swift
+++ b/Sources/ConsoleKit/Command/CommandSignature.swift
@@ -5,7 +5,7 @@
 ///         var name: String
 ///     }
 ///
-public protocol CommandSignature {
+public protocol CommandSignature: Sendable {
     init()
 }
 
@@ -46,7 +46,7 @@ enum InputValue<T: Sendable>: Sendable {
     case uninitialized
 }
 
-internal protocol AnySignatureValue: AnyObject {
+internal protocol AnySignatureValue: AnyObject, Sendable {
     var help: String { get }
     var name: String { get }
     var initialized: Bool { get }

--- a/Sources/ConsoleKit/Command/Commands.swift
+++ b/Sources/ConsoleKit/Command/Commands.swift
@@ -1,5 +1,5 @@
 /// Represents a top-level group of configured commands. This is usually created by calling `resolve(for:)` on `Commands`.
-public struct Commands {
+public struct Commands: Sendable {
     /// Top-level available commands, stored by unique name.
     public var commands: [String: any AnyCommand]
 
@@ -80,7 +80,7 @@ public struct Commands {
     }
 }
 
-private struct _Group: CommandGroup {
+private struct _Group: CommandGroup, Sendable {
     var commands: [String: any AnyCommand]
     var defaultCommand: (any AnyCommand)?
     let help: String

--- a/Sources/ConsoleKit/Command/Completion.swift
+++ b/Sources/ConsoleKit/Command/Completion.swift
@@ -1,5 +1,5 @@
 /// Shell completion implementations.
-public enum Shell: String, LosslessStringConvertible, CaseIterable {
+public enum Shell: String, LosslessStringConvertible, CaseIterable, Sendable {
     case bash
     case zsh
 
@@ -463,7 +463,7 @@ extension AnyAsyncCommand {
 /// An action to be used in the shell completion script(s) to provide
 /// special shell completion behaviors for an `Option`'s argument or a
 /// positional `Argument`.
-public struct CompletionAction {
+public struct CompletionAction: Sendable {
 
     /// The shell-specific implementations of the action.
     public let expressions: [Shell: String]

--- a/Sources/ConsoleKit/Command/Option.swift
+++ b/Sources/ConsoleKit/Command/Option.swift
@@ -5,8 +5,8 @@ import NIOConcurrencyHelpers
 ///     exec command [--opt -o]
 ///
 @propertyWrapper
-public final class Option<Value: Sendable>: AnyOption, Sendable
-    where Value: LosslessStringConvertible
+public final class Option<Value>: AnyOption, Sendable
+    where Value: LosslessStringConvertible & Sendable
 {
     /// The option's identifying name.
     public let name: String

--- a/Sources/ConsoleKitAsyncExample/entry.swift
+++ b/Sources/ConsoleKitAsyncExample/entry.swift
@@ -5,7 +5,7 @@ import Foundation
 struct AsyncExample {
     static func main() async throws {
         let console: Console = Terminal()
-        let input = CommandInput(arguments: CommandLine.arguments)
+        let input = CommandInput(arguments: ProcessInfo.processInfo.arguments)
 
         var commands = AsyncCommands(enableAutocomplete: true)
         commands.use(DemoCommand(), as: "demo", isDefault: false)

--- a/Sources/ConsoleKitExample/main.swift
+++ b/Sources/ConsoleKitExample/main.swift
@@ -3,7 +3,7 @@ import Foundation
 import Logging
 
 let console: Console = Terminal()
-var input = CommandInput(arguments: CommandLine.arguments)
+var input = CommandInput(arguments: ProcessInfo.processInfo.arguments)
 var context = CommandContext(console: console, input: input)
 
 var commands = Commands(enableAutocomplete: true)

--- a/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
+++ b/Tests/ConsoleKitPerformanceTests/ConsoleLoggerPerformanceTests.swift
@@ -8,10 +8,20 @@
 import ConsoleKit
 import Logging
 import XCTest
+import NIOConcurrencyHelpers
 
 final class TestConsole: Console {
-    var lastOutput: String? = nil
-    var userInfo = [AnySendableHashable: any Sendable]()
+    let lastOutput: NIOLockedValueBox<String?> = .init(nil)
+    let _userInfo: NIOLockedValueBox<[AnySendableHashable: any Sendable]> = .init([:])
+    
+    var userInfo: [AnySendableHashable : Sendable] {
+        get {
+            _userInfo.withLockedValue { $0 }
+        }
+        set {
+            _userInfo.withLockedValue { $0 = newValue }
+        }
+    }
     
     func input(isSecure: Bool) -> String {
         ""

--- a/Tests/ConsoleKitTests/CommandTests.swift
+++ b/Tests/ConsoleKitTests/CommandTests.swift
@@ -134,7 +134,7 @@ class CommandTests: XCTestCase {
             }
 
             var help: String = ""
-            var assertion: (Signature) -> ()
+            var assertion: @Sendable (Signature) -> ()
 
             func run(using context: CommandContext, signature: OptionInitialized.Signature) throws {
                 assertion(signature)

--- a/Tests/ConsoleKitTests/Utilities.swift
+++ b/Tests/ConsoleKitTests/Utilities.swift
@@ -88,7 +88,9 @@ final class StrictCommand: Command {
         
         init() { }
     }
-    var help: String = "I error if you pass in bad values"
+    var help: String {
+        "I error if you pass in bad values"
+    }
 
     func run(using context: CommandContext, signature: Signature) throws {
         print("Done!")


### PR DESCRIPTION
Makes `Command` and many of the associated types, like `@Flag` and `@Option` `Sendable`.

Removes all Sendable warnings from ConsoleKit