### PR TITLE
Fix a Sendable warning on Linux

### DIFF
--- a/Sources/ConsoleKit/Activity/ActivityIndicator.swift
+++ b/Sources/ConsoleKit/Activity/ActivityIndicator.swift
@@ -1,4 +1,9 @@
-import Dispatch
+#if os(Linux)
+// Needed because DispatchQueue isn't Sendable on Linux
+@preconcurrency import Foundation
+#else
+import Foundation
+#endif
 #if canImport(Darwin)
 import Darwin
 #else


### PR DESCRIPTION
Fixes an issue where `DispatchQueue` and friends are not `Sendable` on Linux so we need to suppress the warning

Resolves #189 