### PR TITLE
Fix `AnySendableHashable` regression

### DIFF
--- a/Sources/ConsoleKit/Activity/ActivityBar.swift
+++ b/Sources/ConsoleKit/Activity/ActivityBar.swift
@@ -52,11 +52,11 @@ struct ActivityBarWidthKey: Hashable, Equatable {
 extension Console {
     public var activityBarWidth: Int {
         get {
-            self.userInfo[AnySendableHashable(ActivityBarWidthKey())] as? Int ?? 25
+            self.userInfo[ActivityBarWidthKey()] as? Int ?? 25
         }
         
         set {
-            self.userInfo[AnySendableHashable(ActivityBarWidthKey())] = newValue
+            self.userInfo[ActivityBarWidthKey()] = newValue
         }
     }
 }

--- a/Sources/ConsoleKit/Utilities/AnySendableHashable.swift
+++ b/Sources/ConsoleKit/Utilities/AnySendableHashable.swift
@@ -17,3 +17,10 @@ extension AnySendableHashable: CustomStringConvertible, CustomDebugStringConvert
     public var debugDescription: String { self.wrappedValue.debugDescription }
     public var customMirror: Mirror { self.wrappedValue.customMirror }
 }
+
+extension Dictionary where Key == AnySendableHashable {
+    public subscript(key: some Hashable & Sendable) -> Value? {
+        get { self[AnySendableHashable(key)] }
+        set { self[AnySendableHashable(key)] = newValue }
+    }
+}

--- a/Sources/ConsoleKit/Utilities/AnySendableHashable.swift
+++ b/Sources/ConsoleKit/Utilities/AnySendableHashable.swift
@@ -1,26 +1,29 @@
 /// A `Sendable` version of the standard library's `AnyHashable` type.
 public struct AnySendableHashable: @unchecked Sendable, Hashable, ExpressibleByStringLiteral {
     // Note: @unchecked Sendable since there's no way to express that `wrappedValue` is Sendable, even though we ensure that it is in the init.
+    @usableFromInline
     let wrappedValue: AnyHashable
     
+    @inlinable
     public init(_ wrappedValue: some Hashable & Sendable) {
         self.wrappedValue = AnyHashable(wrappedValue)
     }
     
+    @inlinable
     public init(stringLiteral value: String) {
         self.init(value)
     }
 }
 
 extension AnySendableHashable: CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
-    public var description: String { self.wrappedValue.description }
-    public var debugDescription: String { self.wrappedValue.debugDescription }
-    public var customMirror: Mirror { self.wrappedValue.customMirror }
+    @inlinable public var description: String { self.wrappedValue.description }
+    @inlinable public var debugDescription: String { self.wrappedValue.debugDescription }
+    @inlinable public var customMirror: Mirror { self.wrappedValue.customMirror }
 }
 
 extension Dictionary where Key == AnySendableHashable {
     public subscript(key: some Hashable & Sendable) -> Value? {
-        get { self[AnySendableHashable(key)] }
-        set { self[AnySendableHashable(key)] = newValue }
+        @inlinable get { self[AnySendableHashable(key)] }
+        @inlinable set { self[AnySendableHashable(key)] = newValue }
     }
 }


### PR DESCRIPTION
`AnySendableHashable` introduced a breaking change where trying to pass concrete types that conform to `Sendable` and `Hashable` but the compiler couldn't infer they could be passed around as `AnySendableHashable`. This fixes the accesses for any dictionary (including `userInfo`) to fix an API break in https://github.com/vapor/console-kit/releases/tag/4.8.0