### PR TITLE
Revise async commands support

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
     ],
     targets: [
         .target(

--- a/Sources/ConsoleKitCommands/Async/AsyncCommandGroup.swift
+++ b/Sources/ConsoleKitCommands/Async/AsyncCommandGroup.swift
@@ -18,42 +18,10 @@ import ConsoleKitTerminal
 public protocol AsyncCommandGroup: AnyAsyncCommand {
     var commands: [String: any AnyAsyncCommand] { get }
     var defaultCommand: (any AnyAsyncCommand)? { get }
-
-    /// Merges this group with another group.
-    /// - Parameters:
-    ///   - group: The group to merge with.
-    ///   - defaultCommand: The new default command to use.
-    ///   - help: The help message to use for the merged group.
-    /// - Returns: A new `AsyncCommandGroup` with the merged commands.
-    func merge(
-        with group: any AsyncCommandGroup,
-        defaultCommand: (any AnyAsyncCommand)?,
-        help: String
-    ) -> any AsyncCommandGroup
-}
-
-public struct MergedAsyncCommandGroup: AsyncCommandGroup {
-    public let commands: [String: any AnyAsyncCommand]
-    public let defaultCommand: (any AnyAsyncCommand)?
-    public var help: String
 }
 
 extension AsyncCommandGroup {
     public var defaultCommand: (any AnyAsyncCommand)? { nil }
-
-    public func merge(
-        with group: any AsyncCommandGroup,
-        defaultCommand: (any AnyAsyncCommand)?,
-        help: String
-    ) -> any AsyncCommandGroup {
-        var mergedCommands = self.commands
-        mergedCommands.merge(group.commands, uniquingKeysWith: { (_, new) in new })
-        return MergedAsyncCommandGroup(
-            commands: mergedCommands,
-            defaultCommand: defaultCommand,
-            help: help
-        )
-    }
 }
 
 extension AsyncCommandGroup {

--- a/Sources/ConsoleKitCommands/Base/AnyCommand.swift
+++ b/Sources/ConsoleKitCommands/Base/AnyCommand.swift
@@ -25,12 +25,9 @@ extension AnyCommand {
         ""
     }
 
-    // we need to have a sync environment so the compiler uses the sync run method over the async version
-    private func syncRun(using context: inout CommandContext) throws {
-        try self.run(using: &context)
-    }
-
     public func run(using context: inout CommandContext) async throws {
-        try self.syncRun(using: &context)
+        try await withCheckedThrowingContinuation { continuation in
+            continuation.resume(with: .init { try self.run(using: &context) })
+        }
     }
 }

--- a/Sources/ConsoleKitCommands/Base/CommandGroup.swift
+++ b/Sources/ConsoleKitCommands/Base/CommandGroup.swift
@@ -21,14 +21,10 @@ public protocol CommandGroup: AnyCommand, AsyncCommandGroup {
 }
 
 extension CommandGroup {
-    public var defaultCommand: (any AnyCommand)? {
-        nil
-    }
+    public var defaultCommand: (any AnyCommand)? { nil }
 
     public var commands: [String: any AnyAsyncCommand] {
-        // make the compiler happy
-        let castedCommands: [String: any AnyCommand] = commands
-        return castedCommands
+        self.commands as [String: any AnyCommand]
     }
 }
 

--- a/Sources/ConsoleKitCommands/Deprecated/MergedAsyncCommandGroup.swift
+++ b/Sources/ConsoleKitCommands/Deprecated/MergedAsyncCommandGroup.swift
@@ -1,0 +1,17 @@
+@available(*, deprecated, message: "This API should not have been made public and is obsolete; do not use it.")
+public struct MergedAsyncCommandGroup: AsyncCommandGroup {
+    public let commands: [String: any AnyAsyncCommand]
+    public let defaultCommand: (any AnyAsyncCommand)?
+    public var help: String
+}
+
+extension AsyncCommandGroup {
+    @available(*, deprecated, message: "This API should not have been made public and is obsolete; do not use it.")
+    public func merge(
+        with group: any AsyncCommandGroup,
+        defaultCommand: (any AnyAsyncCommand)?,
+        help: String
+    ) -> any AsyncCommandGroup {
+        MergedAsyncCommandGroup(commands: self.commands.merging(group.commands, uniquingKeysWith: { $1 }), defaultCommand: defaultCommand, help: help)
+    }
+}

--- a/Sources/ConsoleKitTerminal/Activity/ActivityIndicator.swift
+++ b/Sources/ConsoleKitTerminal/Activity/ActivityIndicator.swift
@@ -1,13 +1,8 @@
-#if os(Linux)
+#if !canImport(Darwin)
 // Needed because DispatchQueue isn't Sendable on Linux
 @preconcurrency import Foundation
 #else
 import Foundation
-#endif
-#if canImport(Darwin)
-import Darwin
-#else
-import Glibc
 #endif
 import NIOConcurrencyHelpers
 

--- a/Sources/ConsoleKitTerminal/Output/Console+Wait.swift
+++ b/Sources/ConsoleKitTerminal/Output/Console+Wait.swift
@@ -1,8 +1,4 @@
-#if canImport(Darwin)
-import Darwin
-#else
-import Glibc
-#endif
+import Foundation
 
 extension Console {
     /// Blocks the current thread for the specified number of seconds.
@@ -14,8 +10,6 @@ extension Console {
     /// - parameters:
     ///     - seconds: The number of seconds to wait for.
     public func wait(seconds: Double) {
-        let factor = 1000 * 1000
-        let microseconds = seconds * Double(factor)
-        usleep(useconds_t(microseconds))
+        Thread.sleep(forTimeInterval: seconds)
     }
 }

--- a/Sources/ConsoleKitTerminal/Terminal/Terminal.swift
+++ b/Sources/ConsoleKitTerminal/Terminal/Terminal.swift
@@ -1,10 +1,3 @@
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#elseif os(Windows)
-import CRT
-#endif
 import Foundation
 import NIOConcurrencyHelpers
 

--- a/Sources/ConsoleKitTerminal/Utilities/LoggerFragment.swift
+++ b/Sources/ConsoleKitTerminal/Utilities/LoggerFragment.swift
@@ -1,16 +1,5 @@
 import Logging
-
-#if canImport(Darwin)
-import Darwin
-#elseif os(Windows)
-import CRT
-#elseif canImport(Glibc)
-import Glibc
-#elseif canImport(WASILibc)
-import WASILibc
-#else
-#error("Unsupported runtime")
-#endif
+import Foundation
 
 /// Information about a specific log message, including information from the logger the message was logged to.
 public struct LogRecord {


### PR DESCRIPTION
Changes:

- Deprecates unnecessary API
- Corrects the sync `Command` adapter methods
- Cleans up some concurrency warnings