### PR TITLE
Revert unnecessary command behavior change

### DIFF
--- a/Sources/ConsoleKitCommands/Base/AnyCommand.swift
+++ b/Sources/ConsoleKitCommands/Base/AnyCommand.swift
@@ -25,9 +25,12 @@ extension AnyCommand {
         ""
     }
 
+    // we need to have a sync environment so the compiler uses the sync run method over the async version
+    private func syncRun(using context: inout CommandContext) throws {
+        try self.run(using: &context)
+    }
+
     public func run(using context: inout CommandContext) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            continuation.resume(with: .init { try self.run(using: &context) })
-        }
+        try self.syncRun(using: &context)
     }
 }


### PR DESCRIPTION
In a previous release, a change was made (by me) to how old `Command`s are integrated with `AsyncCommand`s which was unnecessary, offers no tangible benefit, possibly has a (very small) speed penalty, and is one of a small number of potential sources of runtime stalls. This reverts said ill-advised change.