### PR TITLE
Support compiling against Musl

### DIFF
--- a/Sources/ConsoleKitTerminal/Terminal/Terminal.swift
+++ b/Sources/ConsoleKitTerminal/Terminal/Terminal.swift
@@ -50,7 +50,7 @@ public final class Terminal: Console, Sendable {
         didOutputLines(count: 1)
         if isSecure {
             var pass = ""
-#if canImport(Darwin) || canImport(Glibc) || os(Android)
+#if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || os(Android)
             func plat_readpassphrase(into buf: UnsafeMutableBufferPointer<Int8>) -> Int {
                 #if canImport(Darwin)
                 let rpp = readpassphrase

--- a/Sources/ConsoleKitTerminal/Terminal/readpassphrase_linux.swift
+++ b/Sources/ConsoleKitTerminal/Terminal/readpassphrase_linux.swift
@@ -2,8 +2,10 @@
 #if (os(Linux) || os(Android)) || (os(macOS) && DEBUG)
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 import Dispatch
 
@@ -50,8 +52,10 @@ internal func linux_readpassphrase(_ prompt: UnsafePointer<Int8>, _ buf: UnsafeM
     sigrecovery.sa_flags = 0
     #if canImport(Darwin)
     sigrecovery.__sigaction_u = .init(__sa_handler: { linux_readpassphrase_signos[$0] += 1 })
-    #elseif os(Linux)
+    #elseif canImport(Glibc)
     sigrecovery.__sigaction_handler = .init(sa_handler: { linux_readpassphrase_signos[$0] += 1 })
+    #elseif canImport(Musl)
+    sigrecovery.__sa_handler = .init(sa_handler: { linux_readpassphrase_signos[$0] += 1 })
     #elseif os(Android)
     sigrecovery.sa_handler = { linux_readpassphrase_signos[$0] += 1 }
     #endif


### PR DESCRIPTION
In order to compile this package against Musl libc, we need to not conflate `#if os(Linux)` with the ability to `import Glibc`. The common pattern for this is to use the `#if canImport` directive.

This patch adds support for Musl by replacing the `Glibc` import conditional alongside a new conditional import of `Musl`.

It also updates the `linux_readpassphrase` implementation to use the appropriate `sigaction` handler field for Musl.