### PR TITLE
Don't animate ActivityIndicator when outputting to a file

### DIFF
--- a/Sources/ConsoleKitTerminal/Activity/ActivityBar.swift
+++ b/Sources/ConsoleKitTerminal/Activity/ActivityBar.swift
@@ -25,7 +25,7 @@ extension ActivityBar {
     public func outputActivityIndicator(to console: any Console, state: ActivityIndicatorState) {
         let bar: ConsoleText
         switch state {
-        case .ready: bar = "[]"
+        case .ready: bar = "[...]"
         case .active(let tick): bar = renderActiveBar(tick: tick, width: console.activityBarWidth)
         case .success: bar = "[Done]".consoleText(.success)
         case .failure: bar = "[Failed]".consoleText(.error)

--- a/Sources/ConsoleKitTerminal/Activity/ActivityIndicator.swift
+++ b/Sources/ConsoleKitTerminal/Activity/ActivityIndicator.swift
@@ -92,7 +92,7 @@ public final class ActivityIndicator<A>: Sendable where A: ActivityIndicatorType
     ///                    when updating the activity.
     public func start(refreshRate: Int = 40) {
         guard console.supportsANSICommands else {
-            // Only output the `.ready` state if the console does not support ANSI commands
+            // Skip animations if the console does not support ANSI commands
             self.activity.outputActivityIndicator(to: self.console, state: .ready)
             return
         }

--- a/Sources/ConsoleKitTerminal/Terminal/Console.swift
+++ b/Sources/ConsoleKitTerminal/Terminal/Console.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Protocol for powering styled Console I/O.
 ///
 /// # Output
@@ -76,4 +78,19 @@ public protocol Console: AnyObject, Sendable {
     func report(error: String, newLine: Bool)
     
     var userInfo: [AnySendableHashable: any Sendable] { get set }
+    
+    /// If the `Console` supports ANSI commands such as color and cursor movement.
+    var supportsANSICommands: Bool { get }
+}
+
+extension Console {
+    public var supportsANSICommands: Bool {
+        #if Xcode
+        // Xcode output does not support ANSI commands
+        return false
+        #else
+        // If STDOUT is not an interactive terminal then omit ANSI commands
+        return isatty(STDOUT_FILENO) > 0
+        #endif
+    }
 }

--- a/Sources/ConsoleKitTerminal/Terminal/Terminal.swift
+++ b/Sources/ConsoleKitTerminal/Terminal/Terminal.swift
@@ -22,11 +22,7 @@ public final class Terminal: Console, Sendable {
         if let stylizeOverride = self.stylizedOutputOverride {
             return stylizeOverride
         }
-        #if Xcode
-            return false
-        #else
-            return isatty(STDOUT_FILENO) > 0
-        #endif
+        return supportsANSICommands
     }
 
     /// Create a new Terminal.


### PR DESCRIPTION
Long running loading/progress indicators create a lot of noisy output when an executable is outputting to Xcode's console, being captured to a file, or a piped to another command. e.g. #141 

This PR skips writing the animated output of an `ActivityIndicator` if the console will not handle it well.

![Jul-15-2024 09-58-42](https://github.com/user-attachments/assets/cc973538-a5ee-4fa6-b2c4-2f13923d0804)
