### PR TITLE
Fix DocC Links

### DIFF
--- a/Sources/ConsoleKit/Docs.docc/index.md
+++ b/Sources/ConsoleKit/Docs.docc/index.md
@@ -6,4 +6,4 @@
 
 Utilities for interacting with a terminal and the commandline in a Swift application.
 
-`ConsoleKit` is an umbrella module, exporting [ConsoleKitTerminal](/consolekitterminal/documentation/consolekitterminal) and [ConsoleKitCommands](/consolekitcommands/documentation/consolekitcommands). It has no separate functionality of its own.
+`ConsoleKit` is an umbrella module, exporting [ConsoleKitTerminal](https://api.vapor.codes/consolekitterminal/documentation/consolekitterminal/) and [ConsoleKitCommands](https://api.vapor.codes/consolekitcommands/documentation/consolekitcommands/). It has no separate functionality of its own.


### PR DESCRIPTION
Fixes the DocC link in the umbrella module. This works around DocC injecting in the base path to any non-fully qualified links.

Resolves #203 