### PR TITLE
Support ANSI commands when using xcodebuild

### DIFF
--- a/Sources/ConsoleKitTerminal/Terminal/Console.swift
+++ b/Sources/ConsoleKitTerminal/Terminal/Console.swift
@@ -88,12 +88,12 @@ public protocol Console: AnyObject, Sendable {
 
 extension Console {
     public var supportsANSICommands: Bool {
-        #if Xcode
-        // Xcode output does not support ANSI commands
-        return false
-        #else
         // If STDOUT is not an interactive terminal then omit ANSI commands
-        return isatty(STDOUT_FILENO) > 0
-        #endif
+        guard isatty(STDOUT_FILENO) > 0 else {
+            return false
+        }
+
+        // "dumb" terminals, such as Xcode's, do not support ANSI commands.
+        return ProcessInfo.processInfo.environment["TERM"] != "dumb"
     }
 }


### PR DESCRIPTION
My project is running into an issue where SPM isn't able to create a multi-arch binary similar to this one:
https://github.com/swiftlang/swift-package-manager/issues/8013

While not quite the same issue, this forum post suggests using `xcodebuild` to resolve issues when building for multiple archs:
https://forums.swift.org/t/swiftpm-compile-multiple-arch-system-library/75724/3

Using `xcodebuild` resolved my issue, but it causes the `#if Xcode` check within `supportsANSICommands` to fail which breaks lots of things.

This PR checks the `TERM` environment variable instead, which Xcode sets to `"dumb"` to indicate that it doesn't support ANSI commands. Cursory searching online leads me to believe this is a common pattern to communicate inability to support ANSI commands.

Testing:
`xcodebuild build -scheme ConsoleKitExample -derivedDataPath DerivedData -destination "generic/platform=macOS"`
then 
`./DerivedData/Build/Products/Debug/ConsoleKitExample`