### PR TITLE
Don't Use Swift Configuration Default Traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.1.1"),
-        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0", traits: [.defaults, "CommandLineArguments"]),
+        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0", traits: ["CommandLineArguments"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Swift Configuration default's traits require full Foundation, which means anything depending on this library will link the full foundation. Since we don't need anything from the default traits, lets not include them
